### PR TITLE
Added linking and expanded info

### DIFF
--- a/src/src/pages/topics/SearchView.js
+++ b/src/src/pages/topics/SearchView.js
@@ -6,7 +6,7 @@ import { Accordion, Spinner } from '@dfds-ui/react-components'
 import { Button, Card, CardContent, IconButton  } from '@dfds-ui/react-components';
 import { Text } from '@dfds-ui/typography';
 import { ChevronDown, ChevronUp, StatusAlert } from '@dfds-ui/icons/system';
-
+import { Link } from "react-router-dom";
 import { getMessageContracts } from "SelfServiceApiClient";
 import Message from "../capabilities/KafkaCluster/MessageContract";
 import TopicsContext from "pages/topics/TopicsContext";
@@ -73,6 +73,11 @@ export function SearchView({data, onTopicClicked}) {
         });
     };
 
+    const linkStyle = {
+        color: "#1874bc",
+        textDecoration: "none",
+    }
+
     useEffect(() => {
         if (selectedKafkaTopic !== data.id) {
             setContracts([]);
@@ -137,6 +142,10 @@ export function SearchView({data, onTopicClicked}) {
                     </>
 
                     }
+
+                    <div >
+                        <div><Text styledAs="actionBold">Capability </Text><Link style={linkStyle} to={`/capabilities/${data.capabilityId}`}>{data.capabilityId}</Link></div>
+                    </div>
                 </CardContent>
             </Card>
         </Accordion>
@@ -147,7 +156,7 @@ export function SearchView({data, onTopicClicked}) {
             :  <div className={styles.infocontainer}>
                     <p>{<HighlightedText text={data.description} highlight={data.highlight ? data.highlight : ""} />}</p>
                     <div >
-                        <div style= {{color: "#1874bc"}}>{data.capabilityId}</div>
+                        <div>Capability: <Link style={linkStyle} to={`/capabilities/${data.capabilityId}`}>{data.capabilityId}</Link></div>
                     </div>
                 </div>
         }


### PR DESCRIPTION
Minor quality of life update:

- Expanding topic details no longer remove capability information.
- Capability ID is a link to that capability.

This is only relevant on the Topics Page