### PR TITLE
Allow listing of consumers for topics one has access to

### DIFF
--- a/src/src/SelfServiceApiClient.js
+++ b/src/src/SelfServiceApiClient.js
@@ -203,6 +203,22 @@ export async function addTopicToCapability(clusterDefinition, topicDefinition) {
     return await response.json();
 }
 
+export async function getConsumers(topicDefinition) {
+    const consumersLink = topicDefinition?._links?.consumers;
+
+    const accessToken = await getSelfServiceAccessToken();
+
+    const url = consumersLink.href;
+    const response = await callApi(url, accessToken);
+
+    if (!response.ok) {
+        return [];
+    }
+
+    const data = await response.json();
+    return data.items;
+}
+
 export async function getMessageContracts(topicDefinition) {
     const messageContractsLink = topicDefinition?._links?.messageContracts;
 

--- a/src/src/pages/capabilities/KafkaCluster/Consumer.js
+++ b/src/src/pages/capabilities/KafkaCluster/Consumer.js
@@ -1,0 +1,7 @@
+import { Text } from '@dfds-ui/typography';
+
+export default function Consumer({name}) {
+    return <div>
+        <Text styledAs="label">{name}</Text>
+    </div>
+}

--- a/src/src/pages/capabilities/KafkaCluster/Topic.js
+++ b/src/src/pages/capabilities/KafkaCluster/Topic.js
@@ -5,12 +5,13 @@ import { Accordion, Spinner } from '@dfds-ui/react-components'
 import { ChevronDown, ChevronUp, StatusAlert, Edit as EditIcon, Delete as DeleteIcon } from '@dfds-ui/icons/system';
 
 import Message from "./MessageContract";
+import Consumer from "./Consumer";
 import styles from "./Topics.module.css";
 import MessageContractDialog from "./MessageContractDialog";
 import { useContext } from "react";
 import SelectedCapabilityContext from "../SelectedCapabilityContext";
 
-import { getMessageContracts } from "SelfServiceApiClient";
+import { getMessageContracts, getConsumers } from "SelfServiceApiClient";
 import Poles from "components/Poles";
 import EditTopicDialog from "./EditTopicDialog";
 import DeleteTopicDialog from "./DeleteTopicDialog";
@@ -62,6 +63,9 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
     const [contracts, setContracts] = useState([]);
     const [isLoadingContracts, setIsLoadingContracts] = useState(false);
 
+    const [consumers, setConsumers] = useState([]);
+    const [isLoadingConsumers, setIsLoadingConsumers] = useState(false);
+
     const [selectedMessageContractId, setSelectedMessageContractId] = useState(null);
     const [showMessageContractDialog, setShowMessageContractDialog] = useState(false);
 
@@ -86,11 +90,14 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
 
         async function fetchData(topic) {
             const result = await getMessageContracts(topic);
+            const consumers = await getConsumers(topic);
             result.sort((a,b) => a.messageType.localeCompare(b.messageType));
 
             if (isMounted) {
               setContracts(result);
               setIsLoadingContracts(false);
+              setConsumers(consumers);
+              setIsLoadingConsumers(false);
             }
         }
 
@@ -103,6 +110,7 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
 
     useEffect(() => {
         setIsLoadingContracts(isSelected);
+        setIsLoadingConsumers(isSelected);
     }, [isSelected]);
 
     const handleHeaderClicked = () => {
@@ -195,6 +203,26 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
                 />
                 
                 <Text>{description}</Text>
+
+                
+                {
+                    isLoadingConsumers
+                    ? <Spinner instant />
+                    :
+                    <>
+                        <br />
+                        <Text styledAs="actionBold">Consumers</Text>
+                        {(consumers || []).length === 0 && 
+                            <div>No one has consumed this topic recently.</div>
+                        }
+
+                        {(consumers || []).map(consumer => <Consumer 
+                            name={consumer}
+                        />)}
+                    </>
+                }
+                        
+                <br />
 
                 {isPublic && 
                     <>


### PR DESCRIPTION
The list of consumers for a specific topic is only available 
- when looking at topics under a specific capability (restriction set in this PR)
- when the logged in user has access to this capability (restriction set in the selfservice-API)
- when looking at the extended information for topics (restriction set in this PR)

Consumers are simply a list of strings, and are rendered as such.

Outstanding questions:
- Should we notify users on what constitutes a consumer (Kafka retention of some data may affect consumer count)?
- Can we live with the above restrictions for now? My idea was to see it in action where it is most critical before rolling things out throughout.