### PR TITLE
Allow listing of consumers for topics one has access to

### DIFF
--- a/src/src/SelfServiceApiClient.js
+++ b/src/src/SelfServiceApiClient.js
@@ -206,6 +206,31 @@ export class SelfServiceApiClient {
         return data.items;
     }
 
+    async getConsumers(topicDefinition) {
+        const link = topicDefinition?._links?.consumers;
+    
+        if (!link) {
+            throw Error("Error! No consumers link found on topic definition: " + JSON.stringify(topicDefinition, null, 2));
+        }
+
+        if (!(link.allow || []).includes("GET")) {
+            throw Error("Error! You are not allowed fetch consumers.");
+        }
+
+        const accessToken = await getSelfServiceAccessToken();
+    
+        const url = link.href;
+        const response = await callApi(url, accessToken);
+        this.responseHandler(response);
+    
+        if (!response.ok) {
+            return [];
+        }
+    
+        const data = await response.json();
+        return data.items;
+    }
+
     async addMessageContractToTopic(topicDefinition, messageContractDescriptor) {
         const messageContractsLink = topicDefinition?._links?.messageContracts;
         if (!messageContractsLink) {

--- a/src/src/pages/capabilities/KafkaCluster/Consumer.js
+++ b/src/src/pages/capabilities/KafkaCluster/Consumer.js
@@ -1,0 +1,7 @@
+import { Text } from '@dfds-ui/typography';
+
+export default function Consumer({name}) {
+    return <div>
+        <Text styledAs="label">{name}</Text>
+    </div>
+}

--- a/src/src/pages/capabilities/KafkaCluster/Topic.js
+++ b/src/src/pages/capabilities/KafkaCluster/Topic.js
@@ -5,6 +5,7 @@ import { Accordion, Spinner } from '@dfds-ui/react-components'
 import { ChevronDown, ChevronUp, StatusAlert, Edit as EditIcon, Delete as DeleteIcon } from '@dfds-ui/icons/system';
 
 import Message from "./MessageContract";
+import Consumer from "./Consumer";
 import styles from "./Topics.module.css";
 import MessageContractDialog from "./MessageContractDialog";
 import { useContext } from "react";
@@ -61,6 +62,9 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
     const [contracts, setContracts] = useState([]);
     const [isLoadingContracts, setIsLoadingContracts] = useState(false);
 
+    const [consumers, setConsumers] = useState([]);
+    const [isLoadingConsumers, setIsLoadingConsumers] = useState(false);
+
     const [selectedMessageContractId, setSelectedMessageContractId] = useState(null);
     const [showMessageContractDialog, setShowMessageContractDialog] = useState(false);
 
@@ -85,11 +89,14 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
 
         async function fetchData(topic) {
             const result = await selfServiceApiClient.getMessageContracts(topic);
+            const consumers = await selfServiceApiClient.getConsumers(topic);
             result.sort((a,b) => a.messageType.localeCompare(b.messageType));
 
             if (isMounted) {
               setContracts(result);
               setIsLoadingContracts(false);
+              setConsumers(consumers);
+              setIsLoadingConsumers(false);
             }
         }
 
@@ -102,6 +109,7 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
 
     useEffect(() => {
         setIsLoadingContracts(isSelected);
+        setIsLoadingConsumers(isSelected);
     }, [isSelected]);
 
     const handleHeaderClicked = () => {
@@ -194,6 +202,26 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
                 />
                 
                 <Text>{description}</Text>
+
+                
+                {
+                    isLoadingConsumers
+                    ? <Spinner instant />
+                    :
+                    <>
+                        <br />
+                        <Text styledAs="actionBold">Consumers</Text>
+                        {(consumers || []).length === 0 && 
+                            <div>No one has consumed this topic recently.</div>
+                        }
+
+                        {(consumers || []).map(consumer => <Consumer 
+                            name={consumer}
+                        />)}
+                    </>
+                }
+                        
+                <br />
 
                 {isPublic && 
                     <>


### PR DESCRIPTION
closes https://github.com/dfds/cloudplatform/issues/1800

The list of consumers for a specific topic is only available

- when looking at topics under a specific capability (restriction set in this PR)
- when the logged in user has access to this capability (restriction set in the selfservice-API)
- when looking at the extended information for topics (restriction set in this PR)
Consumers are simply a list of strings, and are rendered as such.

Outstanding questions:

- Should we notify users on what constitutes a consumer (Kafka retention of some data may affect consumer count)?
- Can we live with the above restrictions for now? My idea was to see it in action where it is most critical before rolling things out throughout.

Depends on dfds/cloudplatform/issues/1799