### PR TITLE
feature/1809 allow for custom error logic for self service request hook

### DIFF
--- a/src/src/ErrorDisplay.js
+++ b/src/src/ErrorDisplay.js
@@ -4,14 +4,14 @@ import Toast from 'components/Toast/index.js'
 
 const ErrorDisplay = () => {
   const { error } = useContext(ErrorContext);
-  
+
   if (error.length === 0 ) {
     return null;
   }
 
   return (
     <div>
-        {(error.map(e => <Toast message={e}></Toast>))}   
+        {(error.map((e, index) => <Toast key={index} message={e}></Toast>))}
     </div>
   );
 };

--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -58,31 +58,26 @@ export function useCapabilities() {
 }
 
 export function useCapabilityById(id) {
-    const { inProgress, responseData, setErrorOptions, sendRequest } = useSelfServiceRequest();
     const [ isLoaded, setIsLoaded ] = useState(false);
     const [ capability, setCapability] = useState(null);
+    const { inProgress, responseData, setErrorOptions, sendRequest } = useSelfServiceRequest({handler: (params => {
+        if (params.error) {
+            params.showError(params.error.message);
+            return;
+        }
 
-    useEffect(() => {
-      setErrorOptions( (prev) => ({...prev, handler: (params => {
-          if (params.error) {
-              params.showError(params.error.message);
-              return;
-          }
+        if (params.httpResponse) {
+            if (params.httpResponse.status === 404) {
+                params.showError("Capability not found");
+                return;
+            }
 
-          if (params.httpResponse) {
-              if (params.httpResponse.status === 404) {
-                  params.showError("Capability not found");
-                  return;
-              }
+            params.showError(params.httpResponse.statusText);
+            return;
+        }
 
-              params.showError(params.httpResponse.statusText);
-              return;
-          }
-
-          params.showError(params.msg);
-      })}));
-    });
-
+        params.showError(params.msg);
+    })});
 
     useEffect(() => {
         if (id != null){

--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -58,10 +58,32 @@ export function useCapabilities() {
 }
 
 export function useCapabilityById(id) {
-    const { inProgress, responseData, errorMessage, sendRequest } = useSelfServiceRequest();
+    const { inProgress, responseData, setErrorOptions, sendRequest } = useSelfServiceRequest();
     const [ isLoaded, setIsLoaded ] = useState(false);
     const [ capability, setCapability] = useState(null);
-    
+
+    useEffect(() => {
+      setErrorOptions( (prev) => ({...prev, handler: (params => {
+          if (params.error) {
+              params.showError(params.error.message);
+              return;
+          }
+
+          if (params.httpResponse) {
+              if (params.httpResponse.status === 404) {
+                  params.showError("Capability not found");
+                  return;
+              }
+
+              params.showError(params.httpResponse.statusText);
+              return;
+          }
+
+          params.showError(params.msg);
+      })}));
+    });
+
+
     useEffect(() => {
         if (id != null){
             sendRequest({
@@ -74,7 +96,7 @@ export function useCapabilityById(id) {
         if (responseData != null){
             setCapability(responseData);
             setIsLoaded(true);
-        }            
+        }
     }, [responseData]);
 
     return {
@@ -84,7 +106,7 @@ export function useCapabilityById(id) {
 }
 
 export function useCapabilityMembers(capabilityDefinition) {
-    const { inProgress, responseData, errorMessage, sendRequest } = useSelfServiceRequest();
+    const { inProgress, responseData, setErrorOptions, sendRequest } = useSelfServiceRequest();
     const [ isLoadedMembers, setIsLoadedMembers ] = useState(false);
     const [ membersList, setMembersList] = useState([]);
 
@@ -125,7 +147,7 @@ export function useCapabilityMembers(capabilityDefinition) {
 
             updateMembers(responseData?.items || []);
         }
-        
+
     }, [responseData]);
 
     useEffect(() => {
@@ -134,7 +156,7 @@ export function useCapabilityMembers(capabilityDefinition) {
         }
 
     }, [membersList]);
-    
+
 
     return {
         isLoadedMembers,

--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -4,7 +4,7 @@ import { getAnotherUserProfilePictureUrl } from "../GraphApiClient";
 
 
 export function useCapabilities() {
-    const { inProgress, responseData: getAllResponse, errorMessage, sendRequest } = useSelfServiceRequest();
+    const { inProgress, responseData: getAllResponse, sendRequest, setErrorOptions } = useSelfServiceRequest();
     const { responseData: addedCapability, sendRequest: addCapability } = useSelfServiceRequest();
     const [ isLoaded, setIsLoaded ] = useState(false);
     const [ capabilities, setCapabilities] = useState([]);

--- a/src/src/hooks/Error.js
+++ b/src/src/hooks/Error.js
@@ -2,47 +2,62 @@ import { useContext, useState } from "react";
 import ErrorContext from "ErrorContext";
 
 export function useError(opts) {
-  const [options, setOptions] = useState(opts);
-  const { showError } =  useContext(ErrorContext);
+    const [options, setOptions] = useState(opts);
+    const { showError } = useContext(ErrorContext);
 
-  const triggerError = (params) => {
-      if (options) {
-          if (options.handler) {
-              params.showError = showError;
-              if (params.msg === null) {
-                  params.msg = options.msg;
-              }
-              options.handler(params);
-          } else {
-              if (params) {
-                  params.showError = showError;
+    ///
+    /// triggerError
+    ///
+    /// Priority of error handling flow
+    ///   1: Handler provided via params
+    ///   2: Handler provided via options
+    ///   3: Error provided via params
+    ///   4: Msg provided via params
+    ///   5: fallbackMsg
+    ///
+    const triggerError = (params) => {
+        // Setup
+        let fallbackMsg = "error";
+        if (params) {
+            params.showError = showError;
+        }
 
-                  if (params.handler) {
-                      params.handler(params);
-                      return;
-                  }
+        if (options?.msg != null) {
+            fallbackMsg = options.msg; // If a catch-all error message is available in options, make sure it is used as a fallback
+        }
 
-                  if (params.error) {
-                      showError(params.error.message);
-                      return;
-                  }
+        // Error handling flow
+        if (params?.handler != null) { // 1: Handler provided via params
+            params.handler(params);
+            return;
+        }
 
-                  if (params.msg) {
-                      showError(params.msg);
-                      return;
-                  }
+        if (options?.handler != null) { // 2: Handler provided via options
+            if (params.msg === null) {
+                params.msg = fallbackMsg;
+            }
+            options.handler(params);
+            return;
+        }
 
-                  showError(options.msg);
-              } else {
-                  showError(options.msg);
-              }
-          }
-      }
-  }
+        if (params) {
+            if (params.error) { // 3: Error provided via params
+                showError(params.error.message);
+                return;
+            }
 
-  return {
-    options,
-    setErrorOptions: setOptions,
-    triggerError
-  }
+            if (params.msg) { // 4: Msg provided via params
+                showError(params.msg);
+                return;
+            }
+        }
+
+        showError(fallbackMsg); // 5: fallbackMsg
+    }
+
+    return {
+        options,
+        setErrorOptions: setOptions,
+        triggerError
+    }
 }

--- a/src/src/hooks/Error.js
+++ b/src/src/hooks/Error.js
@@ -1,0 +1,44 @@
+import { useContext, useState } from "react";
+import ErrorContext from "ErrorContext";
+
+export function useError(opts) {
+  const [options, setOptions] = useState(opts);
+  const { showError } =  useContext(ErrorContext);
+
+  const triggerError = (params) => {
+      if (options) {
+          if (options.handler) {
+              options.handler(params);
+          } else {
+              if (params) {
+                  params.showError = showError;
+
+                  if (params.handler) {
+                      params.handler(params);
+                      return;
+                  }
+
+                  if (params.error) {
+                      showError(params.error.message);
+                      return;
+                  }
+
+                  if (params.msg) {
+                      showError(params.msg);
+                      return;
+                  }
+
+                  showError(options.msg);
+              } else {
+                  showError(options.msg);
+              }
+          }
+      }
+  }
+
+  return {
+    options,
+    setErrorOptions: setOptions,
+    triggerError
+  }
+}

--- a/src/src/hooks/Error.js
+++ b/src/src/hooks/Error.js
@@ -8,6 +8,10 @@ export function useError(opts) {
   const triggerError = (params) => {
       if (options) {
           if (options.handler) {
+              params.showError = showError;
+              if (params.msg === null) {
+                  params.msg = options.msg;
+              }
               options.handler(params);
           } else {
               if (params) {

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -2,7 +2,7 @@ import { callApi, getSelfServiceAccessToken } from "AuthService";
 import { useContext, useEffect, useState } from "react";
 import { composeUrl, composeSegmentsUrl } from "Utils";
 import { useError } from "./Error";
-import { NewErrorTriggerRequestBuilder } from "misc/error";
+import { NewErrorContextBuilder } from "misc/error";
 
 
 
@@ -37,7 +37,7 @@ export function useSelfServiceRequest(errorParams) {
                 const newData = await httpResponse.json();
                 setResponseData(newData);
             } else {
-                triggerError(NewErrorTriggerRequestBuilder()
+                triggerError(NewErrorContextBuilder()
                   .setHttpResponse(httpResponse)
                   // .setHandler((params) => {
                   //   if (params.httpResponse.headers.get("Content-Type") === "application/problem+json") {
@@ -51,7 +51,7 @@ export function useSelfServiceRequest(errorParams) {
 
             }
         } catch (error) {
-            triggerError(NewErrorTriggerRequestBuilder()
+            triggerError(NewErrorContextBuilder()
               .setMsg(error.message)
               .build());
         } finally {

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -39,14 +39,6 @@ export function useSelfServiceRequest(errorParams) {
             } else {
                 triggerError(NewErrorContextBuilder()
                   .setHttpResponse(httpResponse)
-                  // .setHandler((params) => {
-                  //   if (params.httpResponse.headers.get("Content-Type") === "application/problem+json") {
-                  //       const { detail } = await httpResponse.json();
-                  //       setErrorMessage(detail);
-                  //   } else {
-                  //       setErrorMessage("Oh no! We had an issue while retrieving data from the api. Please reload the page.");
-                  //   }
-                  // })
                   .build());
 
             }

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -11,11 +11,12 @@ function isValidURL(urlString) {
     return urlRegex.test(urlString);
   }
 
-export function useSelfServiceRequest() {
+export function useSelfServiceRequest(errorParams) {
     const [responseData, setResponseData] = useState(null);
     const [inProgress, setInProgress] = useState(false);
     const {triggerError, setErrorOptions} = useError({
-      msg: "Oh no! We had an issue while retrieving data from the api. Please reload the page."
+        ...errorParams,
+        msg: "Oh no! We had an issue while retrieving data from the api. Please reload the page."
     });
 
     const sendRequest = async ({ urlSegments, method, payload }) => {

--- a/src/src/hooks/Topics.js
+++ b/src/src/hooks/Topics.js
@@ -4,7 +4,7 @@ import { useSelfServiceRequest } from "./SelfServiceApi";
 
 
 export function useTopics() {
-    const { inProgress, responseData, errorMessage, sendRequest } = useSelfServiceRequest();
+    const { inProgress, responseData, sendRequest, setErrorOptions } = useSelfServiceRequest();
     const [ isLoaded, setIsLoaded ] = useState(false);
     const [ topicsList, setTopicsList] = useState([]);
 

--- a/src/src/misc/error.js
+++ b/src/src/misc/error.js
@@ -1,0 +1,44 @@
+export class ErrorOptions {
+  msg = "";
+  handler = (params) => {};
+}
+
+class ErrorTriggerRequest {
+  httpResponse = null;
+  error = null;
+  msg = null;
+  handler = null;
+  showError = null;
+}
+
+class ErrorTriggerRequestBuilder {
+  val = new ErrorTriggerRequest();
+
+  setHttpResponse(input) {
+    this.val.httpResponse = input;
+    return this;
+  }
+
+  setError(input) {
+    this.val.error = input;
+    return this;
+  }
+
+  setMsg(input) {
+    this.val.msg = input;
+    return this;
+  }
+
+  setHandler(input) {
+    this.val.handler = input;
+    return this;
+  }
+
+  build() {
+    return this.val;
+  }
+}
+
+export function NewErrorTriggerRequestBuilder() {
+  return new ErrorTriggerRequestBuilder();
+}

--- a/src/src/misc/error.js
+++ b/src/src/misc/error.js
@@ -3,7 +3,7 @@ export class ErrorOptions {
   handler = (params) => {};
 }
 
-class ErrorTriggerRequest {
+class ErrorContext {
   httpResponse = null;
   error = null;
   msg = null;
@@ -11,8 +11,8 @@ class ErrorTriggerRequest {
   showError = null;
 }
 
-class ErrorTriggerRequestBuilder {
-  val = new ErrorTriggerRequest();
+class ErrorContextBuilder {
+  val = new ErrorContext();
 
   setHttpResponse(input) {
     this.val.httpResponse = input;
@@ -39,6 +39,6 @@ class ErrorTriggerRequestBuilder {
   }
 }
 
-export function NewErrorTriggerRequestBuilder() {
-  return new ErrorTriggerRequestBuilder();
+export function NewErrorContextBuilder() {
+  return new ErrorContextBuilder();
 }


### PR DESCRIPTION
For context, see: https://github.com/dfds/cloudplatform/issues/1809

- Added generalised Error hook & helper classes
- Make sure components spawned from .map has a key so React can identify components
- Updated SelfServiceApi hook to use the new Error hook
- Added error handler for useCapabilityById (mostly for demonstrating how a custom handler can be attached)

---

~~Not sure if I'm happy with the naming of "_NewErrorTriggerRequestBuilder_" 😅~~

Would appreciate feedback of any kind. Perhaps it's too convoluted?