### PR TITLE
Remove exceptions and check for consumer permissions

### DIFF
--- a/src/src/SelfServiceApiClient.js
+++ b/src/src/SelfServiceApiClient.js
@@ -210,11 +210,12 @@ export class SelfServiceApiClient {
         const link = topicDefinition?._links?.consumers;
     
         if (!link) {
-            throw Error("Error! No consumers link found on topic definition: " + JSON.stringify(topicDefinition, null, 2));
+            return [];
         }
 
+        // If we are _not_ allowed to get consumers, simply return nothing
         if (!(link.allow || []).includes("GET")) {
-            throw Error("Error! You are not allowed fetch consumers.");
+            return [];
         }
 
         const accessToken = await getSelfServiceAccessToken();

--- a/src/src/pages/capabilities/KafkaCluster/Topic.js
+++ b/src/src/pages/capabilities/KafkaCluster/Topic.js
@@ -203,21 +203,30 @@ export default function Topic({topic, isSelected, onHeaderClicked}) {
                 
                 <Text>{description}</Text>
 
-                
-                {
-                    isLoadingConsumers
-                    ? <Spinner instant />
-                    :
+                {/* Consumers currently only fetchable for public topics due to constraints on the API */}
+                {isPublic &&
                     <>
                         <br />
                         <Text styledAs="actionBold">Consumers</Text>
-                        {(consumers || []).length === 0 && 
-                            <div>No one has consumed this topic recently.</div>
-                        }
 
-                        {(consumers || []).map(consumer => <Consumer 
-                            name={consumer}
-                        />)}
+                        {isLoadingConsumers
+                        ? <Spinner instant />
+                        :
+                        <>
+                            <br />
+                            {!(topic._links.consumers.allow || []).includes("GET") &&
+                                <div>Only members of capabilities can see public topic consumers.</div>
+                            }
+
+                            {(consumers || []).length === 0 && (topic._links.consumers.allow || []).includes("GET") &&
+                                <div>No one has consumed this topic recently.</div>
+                            }
+
+                            {(consumers || []).map(consumer => <Consumer 
+                                name={consumer}
+                            />)}
+                        </>
+                        }
                     </>
                 }
                         


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1856

# Additional Review Notes
If users are not allowed to list consumers from the backend, this threw an error that prevented the frontend from finishing loading.
End result: infinite spinners and lack of data.

Solution:
* Do not throw exceptions when missing permissions; Instead return nothing
* Test for permissions to provide proper message in the UI
