### PR TITLE
Feature/1840 create stagingdev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN cd /app/src/ && npm install && npm run build
 
 FROM nginx:alpine
 
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /app/src/build/ /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
+ARG REACT_APP_AUTH_REDIRECT_URL
+ARG REACT_APP_API_BASE_URL
+
 FROM node:18 as build
+
+ARG REACT_APP_AUTH_REDIRECT_URL
+ARG REACT_APP_API_BASE_URL
 
 COPY src/ /app/src/
 RUN cd /app/src/ && npm install && npm run build
 
 FROM nginx:alpine
-
-COPY nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=build /app/src/build/ /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+FROM node:18 as build
+
+COPY src/ /app/src/
+RUN cd /app/src/ && npm install && npm run build
+
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY ./.output/app /usr/share/nginx/html
+
+COPY --from=build /app/src/build/ /usr/share/nginx/html


### PR DESCRIPTION
Build selfservice-portal within the build container for the Dockerfile, rather than building it on the host machine and the copying it into the final container image.

Done as part of https://github.com/dfds/cloudplatform/issues/1893