### PR TITLE
Display cost text in My Capabilities

### DIFF
--- a/src/src/CapabilityCostsWrapper.js
+++ b/src/src/CapabilityCostsWrapper.js
@@ -1,20 +1,3 @@
-export class CapabilityCosts{
-
-constructor(){
-  this.rechartsCosts = [];
-  this.rawCosts = [];
-  this.average = 0.0;
-  }
-
-  addCost(cost){
-    this.rawCosts.push(cost);
-    this.rechartsCosts.push({name:cost.timestamp, pv:cost.value});
-  }
-   calculateAndSetAverage(){
-
-  }
-}
-
 export class CapabilityCostsWrapper {
   static get ForceCheckInterval() {
     return 60 * 5; // 5 minutes
@@ -32,7 +15,7 @@ export class CapabilityCostsWrapper {
   }
 
   async tryUpdateMyCapabilityCosts() {
-    let now = new Date().getTime()
+    let now = new Date().getTime();
     if (this.has_set_costs && this.next_forced_update > now) {
       return true;
     }

--- a/src/src/CapabilityCostsWrapper.js
+++ b/src/src/CapabilityCostsWrapper.js
@@ -1,3 +1,20 @@
+export class CapabilityCosts{
+
+constructor(){
+  this.rechartsCosts = [];
+  this.rawCosts = [];
+  this.average = 0.0;
+  }
+
+  addCost(cost){
+    this.rawCosts.push(cost);
+    this.rechartsCosts.push({name:cost.timestamp, pv:cost.value});
+  }
+   calculateAndSetAverage(){
+
+  }
+}
+
 export class CapabilityCostsWrapper {
   static get ForceCheckInterval() {
     return 60 * 5; // 5 minutes
@@ -33,7 +50,7 @@ export class CapabilityCostsWrapper {
       responseCost.costs.forEach((cost) => {
         let chartStructure = {
           name: cost.timeStamp,
-          pv: cost.value.toFixed(2),
+          pv: Math.floor(cost.value),
         };
         costsMap.get(capabilityId).push(chartStructure);
       });

--- a/src/src/components/BasicCapabilityCost/index.js
+++ b/src/src/components/BasicCapabilityCost/index.js
@@ -14,9 +14,11 @@ export function CapabilityCostSummary({ data }) {
   const d1 = Math.min(...data.map((x) => x.pv)) * 0.95;
   const d2 = Math.max(...data.map((x) => x.pv)) * 1.05;
 
+  const lastDay = data[data.length - 1].pv;
   const domain = [d1, d2];
   return (
-    <div className={styles.costDataSummary}>
+    <div className={styles.chartContainer}>
+      <div className={styles.costDataSummary}>
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data}>
           <XAxis dataKey="timestamp" hide />
@@ -33,6 +35,9 @@ export function CapabilityCostSummary({ data }) {
           />
         </LineChart>
       </ResponsiveContainer>
+      </div>
+      <div className={styles.costDataSummaryCost}>${lastDay}</div>
+
     </div>
   );
 }

--- a/src/src/components/BasicCapabilityCost/index.js
+++ b/src/src/components/BasicCapabilityCost/index.js
@@ -14,30 +14,39 @@ export function CapabilityCostSummary({ data }) {
   const d1 = Math.min(...data.map((x) => x.pv)) * 0.95;
   const d2 = Math.max(...data.map((x) => x.pv)) * 1.05;
 
-  const lastDay = data[data.length - 1].pv;
+
+
+  const averageCost = Math.floor(
+    data.reduce((acc, x) => acc + x.pv, 0) / data.length,
+  );
+
+  let displayedCost = averageCost < 1 ? "<$1/d" : `$${averageCost}/d`;
+
   const domain = [d1, d2];
   return (
     <div className={styles.chartContainer}>
       <div className={styles.costDataSummary}>
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
-          <XAxis dataKey="timestamp" hide />
-          <YAxis type="number" domain={[d1,d2]} hide></YAxis>
-          <Tooltip content={CostTooltip} />
-          <CartesianGrid />
-          <Line
-            type="monotone"
-            dataKey="pv"
-            stroke="#014874"
-            strokeWidth={2}
-            dot={false}
-            isAnimationActive={false}
-          />
-        </LineChart>
-      </ResponsiveContainer>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <XAxis dataKey="timestamp" hide />
+            <YAxis type="number" domain={domain} hide></YAxis>
+            <Tooltip content={CostTooltip} />
+            <CartesianGrid />
+            <Line
+              type="monotone"
+              dataKey="pv"
+              stroke="#014874"
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
       </div>
-      <div className={styles.costDataSummaryCost}>${lastDay}</div>
-
+      <div className={styles.costDataSummaryCostContainer}>
+        <div className={styles.costDataSummaryCostAvg}>Average</div>
+        <div className={styles.costDataSummaryCost}>{displayedCost}</div>
+      </div>
     </div>
   );
 }

--- a/src/src/components/BasicCapabilityCost/index.js
+++ b/src/src/components/BasicCapabilityCost/index.js
@@ -27,16 +27,17 @@ export function CapabilityCostSummary({ data }) {
     <div className={styles.chartContainer}>
       <div className={styles.costDataSummary}>
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={data}>
+          <LineChart data={data}  >
             <XAxis dataKey="timestamp" hide />
             <YAxis type="number" domain={domain} hide></YAxis>
             <Tooltip content={CostTooltip} />
-            <CartesianGrid />
+            <CartesianGrid strokeDasharray="1"/>
             <Line
               type="monotone"
               dataKey="pv"
               stroke="#014874"
               strokeWidth={2}
+
               dot={false}
               isAnimationActive={false}
             />

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -7,14 +7,20 @@
 }
 
 .costDataSummary {
-  max-width: 150px;
+  width: 150px;
   height: 30px;
 }
 
-.costDataSummaryCost {
+.costDataSummaryCostAvg {
   height: 100%;
   font-size: 10px;
-  text-align: right;
+  text-align: center;
+}
+.costDataSummaryCost {
+  height: 100%;
+  width: 100%;
+  font-size: 10px;
+    text-align: right;
 }
 
 .largeCostDataSummary {

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -1,12 +1,24 @@
+
+.chartContainer {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding-right: 10px;
+}
+
 .costDataSummary {
-  width: 90%;
-  height: 30px;
-  display: inline-block;
-  align-content: flex-start;
+  width: 200px;
+  padding-right: 2px;
+}
+
+.costDataSummaryCost {
+  height: 100%;
+  font-size: 10px;
+  text-align: right;
 }
 
 .largeCostDataSummary {
-  width: 100%;
   height: 300px;
 }
 
@@ -22,9 +34,4 @@
 
 .tooltipValue {
   font-size: 1.2em;
-}
-
-.chartContainer {
-  display: flex;
-  align-items: center;
 }

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -3,6 +3,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding-right: 7px;
 }
 
 .costDataSummary {

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -4,12 +4,11 @@
   height: 100%;
   display: flex;
   align-items: center;
-  padding-right: 10px;
 }
 
 .costDataSummary {
-  width: 200px;
-  padding-right: 2px;
+  max-width: 150px;
+  height: 30px;
 }
 
 .costDataSummaryCost {

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -1,42 +1,49 @@
 
 .chartContainer {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .costDataSummary {
-  width: 150px;
-  height: 30px;
+    width: 150px;
+    height: 35px;
+}
+.costDataSummaryCostContainer{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding-left: 5px;
+    line-height: 1.4;
 }
 
 .costDataSummaryCostAvg {
-  height: 100%;
-  font-size: 10px;
-  text-align: center;
+    color: #7e7e7e;
+    font-size: 11px;
+    text-align: center;
 }
+
 .costDataSummaryCost {
-  height: 100%;
-  width: 100%;
-  font-size: 10px;
-    text-align: right;
+    color: #595959;
+    font-size: 11px;
+    text-align: center;
 }
 
 .largeCostDataSummary {
-  height: 300px;
+    height: 300px;
 }
 
 .customTooltip {
-  background-color: #01314e;
-  color: #ffffff;
-  opacity: 85%;
+    background-color: #01314e;
+    color: #ffffff;
+    opacity: 85%;
 }
 
 .tooltipName {
-  color: #c9c9c9;
+    color: #c9c9c9;
 }
 
 .tooltipValue {
-  font-size: 1.2em;
+    font-size: 1.2em;
 }

--- a/src/src/pages/capabilities/MyCapabilities.js
+++ b/src/src/pages/capabilities/MyCapabilities.js
@@ -96,6 +96,7 @@ export default function MyCapabilities() {
                         </Text>
                       ) : (
                         <>
+                          <div className={styles.costs}>
                           <CapabilityCostSummary
                             data={capabilityCosts.getCostsForCapability(
                               x.id,
@@ -103,6 +104,7 @@ export default function MyCapabilities() {
                             )}
                           />
                           <ChevronRight />
+                          </div>
                         </>
                       )}
                     </TableDataCell>

--- a/src/src/pages/capabilities/myCapabilities.module.css
+++ b/src/src/pages/capabilities/myCapabilities.module.css
@@ -3,3 +3,10 @@
   margin: 0px -20px;
   float: left;
 }
+
+.costs{
+  width: 100%;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+}


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1903

# Additional Review Notes
Currently a cost curves are displayed to the right of capabilities in the My Capabilities section, however it is only displaying cost trends and not the actual costs, e.g. two curves might look the same but one capability could have costs 10 times higher than the other.

This PR adds an average cost for the period (7 days) displayed to the right of the cost curve like so:
![image](https://github.com/dfds/selfservice-portal/assets/5738476/5136f4aa-6407-4825-9f55-508155f01d76)
