### PR TITLE
feat/1918 selfservice portal add embed code for matomo

### DIFF
--- a/src/src/App.js
+++ b/src/src/App.js
@@ -46,7 +46,7 @@ export default function App() {
       var _mtm = window._mtm = window._mtm || [];
       _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src='http://localhost:3003/js/container_5dUPH73l.js'; s.parentNode.insertBefore(g,s);
+      g.async=true; g.src='https://build.dfds.cloud/tr/js/container_nbYsx3GM.js'; s.parentNode.insertBefore(g,s);
     }, []);
 
   return (

--- a/src/src/App.js
+++ b/src/src/App.js
@@ -41,14 +41,6 @@ function Layout() {
 }
 
 export default function App() {
-
-  React.useEffect(() => {
-      var _mtm = window._mtm = window._mtm || [];
-      _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src='https://build.dfds.cloud/tr/js/container_nbYsx3GM.js'; s.parentNode.insertBefore(g,s);
-    }, []);
-
   return (
     <>
       <Routes>

--- a/src/src/App.js
+++ b/src/src/App.js
@@ -41,6 +41,14 @@ function Layout() {
 }
 
 export default function App() {
+
+  React.useEffect(() => {
+      var _mtm = window._mtm = window._mtm || [];
+      _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src='http://localhost:3003/js/container_5dUPH73l.js'; s.parentNode.insertBefore(g,s);
+    }, []);
+
   return (
     <>
       <Routes>

--- a/src/src/TrackingContext.js
+++ b/src/src/TrackingContext.js
@@ -10,7 +10,6 @@ function TrackingProvider({ children }) {
 
   useEffect(() => {
     if (isEnabled) {
-      console.log("Tracking enabled");
       var _mtm = window._mtm = window._mtm || [];
       _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];

--- a/src/src/TrackingContext.js
+++ b/src/src/TrackingContext.js
@@ -1,0 +1,28 @@
+import React, { useState, useEffect, useContext, useMemo } from "react";
+
+const TrackingContext = React.createContext(null);
+
+function TrackingProvider({ children }) {
+  let isEnabled = false;
+  if (window.env === "production") {
+    isEnabled = true;
+  }
+
+  useEffect(() => {
+    if (isEnabled) {
+      console.log("Tracking enabled");
+      var _mtm = window._mtm = window._mtm || [];
+      _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src='https://build.dfds.cloud/tr/js/container_nbYsx3GM.js'; s.parentNode.insertBefore(g,s);
+    }
+  }, []);
+
+  const state = {
+    trackingIsEnabled: isEnabled
+  };
+
+  return <TrackingContext.Provider value={state}>{children}</TrackingContext.Provider>;
+}
+
+export { TrackingContext as default, TrackingProvider };

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -3,6 +3,8 @@ import { useContext, useEffect, useState } from "react";
 import { composeUrl, composeSegmentsUrl } from "Utils";
 import { useError } from "./Error";
 import { NewErrorContextBuilder } from "misc/error";
+import { useTracking } from "./Tracking";
+
 
 function isValidURL(urlString) {
   const urlRegex = /^(?:https?:\/\/)/;
@@ -16,6 +18,7 @@ export function useSelfServiceRequest(errorParams) {
     ...errorParams,
     msg: "Oh no! We had an issue while retrieving data from the api. Please reload the page.",
   });
+  const {track} = useTracking();
 
   const sendRequest = async ({ urlSegments, method, payload }) => {
     setInProgress(true);
@@ -27,8 +30,7 @@ export function useSelfServiceRequest(errorParams) {
       url = urlSegments[0];
     }
 
-    // eslint-disable-next-line no-undef
-    _paq.push(['trackEvent', 'selfservice', `${method}::${url}`, '1']);
+    track('selfservice', `${method}::${url}`, '1')
 
     try {
       const httpResponse = await callApi(url, accessToken, method, payload);

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -27,6 +27,9 @@ export function useSelfServiceRequest(errorParams) {
       url = urlSegments[0];
     }
 
+    // eslint-disable-next-line no-undef
+    _paq.push(['trackEvent', 'selfservice', `${method}::${url}`, '1']);
+
     try {
       const httpResponse = await callApi(url, accessToken, method, payload);
 

--- a/src/src/hooks/Tracking.js
+++ b/src/src/hooks/Tracking.js
@@ -1,0 +1,18 @@
+import { useContext, useState } from "react";
+import TrackingContext from 'TrackingContext';
+
+export function useTracking(opts) {
+  const { trackingIsEnabled } = useContext(TrackingContext);
+
+  let track = (...opts) => {
+    if (trackingIsEnabled) {
+      // eslint-disable-next-line no-undef
+      _paq.push(['trackEvent', ...opts]);
+    }
+  }
+
+
+  return {
+    track
+  };
+}

--- a/src/src/index.js
+++ b/src/src/index.js
@@ -8,8 +8,10 @@ import { AppProvider } from "./AppContext";
 import { MsalProvider } from "@azure/msal-react";
 import { MsalInstance } from "./AuthService";
 import { ErrorProvider } from "ErrorContext";
+import { TrackingProvider } from "TrackingContext";
 
 window.apiBaseUrl = process.env.REACT_APP_API_BASE_URL;
+window.env = process.env.NODE_ENV;
 
 render(
   <React.StrictMode>
@@ -17,9 +19,11 @@ render(
       <BrowserRouter basename={process.env.PUBLIC_URL}>
         <GlobalStyles />
         <ErrorProvider>
-          <AppProvider>
-            <App />
-          </AppProvider>
+          <TrackingProvider>
+            <AppProvider>
+              <App />
+            </AppProvider>
+          </TrackingProvider>
         </ErrorProvider>
       </BrowserRouter>
     </MsalProvider>


### PR DESCRIPTION
Issue: https://github.com/dfds/cloudplatform/issues/1918
Added a Provider & Hook for tracking.

The provider will only enable tracking if the JS bundle is detected as a production build
The hook was added to make it so we only do the conditional checks in one place, rather than everywhere we might want to add custom tracking