### PR TITLE
Indication of deletion

### DIFF
--- a/src/src/pages/capabilities/SelectedCapabilityContext.js
+++ b/src/src/pages/capabilities/SelectedCapabilityContext.js
@@ -38,6 +38,7 @@ function SelectedCapabilityProvider({ children }) {
   const { capability, isLoaded } = useCapabilityById(capabilityId);
   const { membersList, isLoadedMembers } = useCapabilityMembers(details);
   const [isPendingDeletion, setPendingDeletion] = useState(null);
+  const [isDeleted, setIsDeleted] = useState(null);
   const [showCosts, setShowCosts] = useState(false);
 
   // load kafka clusters and topics
@@ -319,6 +320,7 @@ function SelectedCapabilityProvider({ children }) {
     if (isLoaded) {
       setDetails(capability);
       setPendingDeletion(capability.status === "Pending Deletion");
+      setIsDeleted(capability.status === "Deleted");
     }
   }, [isLoaded, capability]);
 
@@ -382,6 +384,7 @@ function SelectedCapabilityProvider({ children }) {
     submitDeleteCapability,
     submitCancelDeleteCapability,
     isPendingDeletion,
+    isDeleted,
     updateDeletionStatus,
     showCosts,
   };

--- a/src/src/pages/capabilities/details.js
+++ b/src/src/pages/capabilities/details.js
@@ -33,6 +33,7 @@ function CapabilityDetailsPageContent() {
     showResources,
     showCosts,
     isPendingDeletion,
+    isDeleted,
     updateDeletionStatus,
   } = useContext(SelectedCapabilityContext);
 
@@ -41,13 +42,15 @@ function CapabilityDetailsPageContent() {
     loadCapability(id);
   }, [id]);
 
+  const pagetitle = isDeleted ? `${name} [Deleted]` : name;
+
   return (
     <>
       <DeletionWarning
         deletionState={isPendingDeletion}
         updateDeletionState={updateDeletionStatus}
       />
-      <Page title={name} isLoading={isLoading} isNotFound={!isFound}>
+      <Page title={pagetitle} isLoading={isLoading} isNotFound={!isFound}>
         <Members />
         <Summary />
         {showResources && <Resources />}


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1955

# Additional Review Notes
Forgot to modify the frontend before considering the task closed.

On the overview page, all deleted capabilities will be highlighted with the warning icon, just the same as pending deletion. This is already in the code.
On the details page, the title will say 'Deleted'.

These are not perfect, but they are something to start with. Then we can see how the OPS teams use this newfound power and modify accordingly.