### PR TITLE
Fix warnings from dependabot

### DIFF
--- a/fake_dependencies/selfservice-api/package.json
+++ b/fake_dependencies/selfservice-api/package.json
@@ -24,6 +24,7 @@
     "esm": "^3.2.25",
     "express": "^4.18.2",
     "nodemon": "^2.0.20",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "semver": "^7.5.2"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -22,7 +22,6 @@
     "react-dom": "18.2.0",
     "react-json-view": "^1.21.3",
     "react-router-dom": "^6.5.0",
-    "react-scripts": "^5.0.1",
     "react-select": "5.7.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-tooltip": "^5.21.1",
@@ -74,6 +73,7 @@
     ]
   },
   "devDependencies": {
+    "react-scripts": "^5.0.1",
     "@azure/msal-browser": "^2.32.2",
     "@azure/msal-react": "^1.5.2",
     "prettier": "3.0.1"


### PR DESCRIPTION
# Additional Review Notes
The semver version should be used for the current dependencies, of which we have multiple in package-lock.

The react-scripts are a build tool and any issue therein are not an issue in production.
Moving this to dev-dependencies hopefully silences github's dependabot.