### PR TITLE
Feature/1969: Error details and improved styling

### DIFF
--- a/src/src/ErrorContext.js
+++ b/src/src/ErrorContext.js
@@ -1,13 +1,14 @@
 import ErrorDisplay from "ErrorDisplay";
-import React, { createContext, useState } from "react";
+import React, { createContext, useEffect, useState } from "react";
 
 const ErrorContext = createContext();
 
 function ErrorProvider({ children }) {
   const [error, setError] = useState([]);
 
-  const showError = (errorMessage) =>
-    setError((prevError) => [...prevError, errorMessage]);
+  const showError = (errorMessage) => {
+    setError((prevError) => [...prevError, errorMessage])
+  };
 
   return (
     <ErrorContext.Provider value={{ error, showError }}>

--- a/src/src/ErrorDisplay.js
+++ b/src/src/ErrorDisplay.js
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import ErrorContext from "./ErrorContext";
 import Toast from "components/Toast/index.js";
+import styles from "errordisplay.module.css"
 
 const ErrorDisplay = () => {
   const { error } = useContext(ErrorContext);
@@ -10,9 +11,11 @@ const ErrorDisplay = () => {
   }
 
   return (
-    <div>
+    <div className={styles.toasts_container}>
       {error.map((e, index) => (
+        <>
         <Toast key={index} message={e}></Toast>
+        </>
       ))}
     </div>
   );

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -1,29 +1,96 @@
 import styles from "./toast.module.css";
 import { Close } from "@dfds-ui/icons/system";
-import { useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Button } from "@dfds-ui/react-components";
+import { Modal, ModalAction } from "@dfds-ui/modal";
+import { set } from "date-fns";
 
-export default function Toast({ message }) {
-  const [isOpen, setIsOpen] = useState(true);
-  if (!isOpen) {
-    return null;
-  }
+/*
+ * This hook is used to get the previous value of a prop or state.
+ */
+function usePrevious(value) {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}
+
+export default function Toast({ message, details }) {
+  const [showToast, setShowToast] = useState(true);
+  const [showDetails, setShowDetails] = useState(false);
+  const [opacity, setOpacity] = useState(0);
+  const prevOpacity = usePrevious(opacity);
+  const [hide, setHide] = useState(false);
+  const prevHide = usePrevious(hide);
+ 
+  const actions = (
+    <>
+      <ModalAction
+        style={{ marginRight: "1rem" }}
+        actionVariation="secondary"
+        onClick={() => setShowDetails(false)}
+      >
+        Close
+      </ModalAction>
+    </>
+  )
+
+  useEffect(() => {
+    setTimeout(() => {
+      setOpacity(0.8)
+    }, 100) // arbitrary delay to allow the toast to render before fading in
+  }, []);
+
+  useEffect(() => {
+    if (prevOpacity != undefined && opacity === 0) {
+      setTimeout(() => {
+        setHide(true);
+      }, 300); // 300ms is the duration of the fade-out animation
+    }
+  }, [opacity]);
+
+  useEffect(() => {
+    if (prevHide != undefined && hide === true) {
+      setTimeout(() => {
+        setShowToast(false);
+      }, 2000); // 300ms is the duration of the squeeze animation
+    }
+  }, [hide]);
 
   return (
-    <div className={styles.container_toast}>
-      <div className={styles.container_toast_message}>
-        <div className={styles.textbox}>{message}</div>
-        <div className={styles.actionbox}>
-          <div onClick={() => setIsOpen(false)}>
-            <Close />
-          </div>
+    <>
+    {showDetails && details && (
+    <Modal
+        heading={`Details`}
+        isOpen={true}
+        shouldCloseOnOverlayClick={true}
+        shouldCloseOnEsc={true}
+        onRequestClose={() => setShowDetails(false)}
+        actions={actions}
+    >
+      {details ? details : "No details available"}
+    </Modal>)}
+    {showToast && (
+    <div className={`${styles.toast_container} ${hide ? styles.hidden : ''}`} style={{"opacity": opacity}}>
+        <div className={styles.toast_close_bar}>
+          <Button size="small" variation="link" fillWidth="true" onClick={() => setOpacity(0)} >
+            <Close className={styles.close_icon} />
+          </Button>
         </div>
-      </div>
-      <div>
-        <Button size="small" variation="link" fillWidth="true">
-          Details
-        </Button>
-      </div>
+        <div className={styles.toast_message}>
+          {message}
+        </div>
+        <br />
+        {details && (
+        <div>
+          <Button size="small" variation="link" fillWidth="true" onClick={() => setShowDetails(true)}>
+            <span className={styles.toast_details_button}>Details</span>
+          </Button>
+        </div>
+        )}
     </div>
+    )}
+    </>
   );
 }

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -1,6 +1,7 @@
 import styles from "./toast.module.css";
 import { Close } from "@dfds-ui/icons/system";
 import { useState } from "react";
+import { Button } from "@dfds-ui/react-components";
 
 export default function Toast({ message }) {
   const [isOpen, setIsOpen] = useState(true);
@@ -10,12 +11,18 @@ export default function Toast({ message }) {
 
   return (
     <div className={styles.container_toast}>
-      <div className={styles.textbox}>{message}</div>
-      <div className={styles.actionbox}>
-        <div className={styles.toast_close} onClick={() => setIsOpen(false)}>
-          <Close />
+      <div className={styles.container_toast_message}>
+        <div className={styles.textbox}>{message}</div>
+        <div className={styles.actionbox}>
+          <div onClick={() => setIsOpen(false)}>
+            <Close />
+          </div>
         </div>
-        {/* <Button size="small" variation="outlined">Details</Button> */}
+      </div>
+      <div>
+        <Button size="small" variation="link" fillWidth="true">
+          Details
+        </Button>
       </div>
     </div>
   );

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -1,18 +1,16 @@
-.container_toast {
-  display: flex;
-  flex-direction: column;
-  background-color: rgba(190, 30, 45, 0.8);
+.toast_container {
+  background-color: rgba(190, 30, 45);
   width: 284px;
-  cursor: default;
-  position: fixed;
-  left: 50%; /* Position the element at the horizontal center */
-  transform: translateX(-50%);
-  bottom: 1rem;
-  z-index: 10000;
-  box-sizing: border-box;
-  align-items: center;
-  justify-content: center;
   border-radius: 5px;
+  margin: 5px;
+  opacity: 0;
+  transition: 300ms all ease;
+  height: 120px;
+}
+.hidden {
+  height: 0;
+  padding: 0;
+  margin: 0;
 }
 
 .container_toast_message{
@@ -20,43 +18,28 @@
   justify-content: center;
 }
 
-
-/* Toast Close Button */
-.toast_close {
-  display: flex;
+.toast_close_bar {
+  width: 100%;
+  text-align: right;
+  padding-right: 0.5rem;
+}
+.toast_close_bar button {
+  width: 20px;
+}
+.close_icon {
+  font-size: 20px;
+  font-weight: bold;
+  color: #fff;
 }
 
-.toast_close:hover {
-  background-color: #920916;
-}
-
-.textbox {
-  display: flex;
+.toast_message {
   color: #ffffff;
   text-align: center;
   padding: 0.5rem;
 }
 
-.actionbox {
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 0.1rem 0.35rem 0 0.35rem;
-  color: #fff;
-}
-
-
-.actionbox > Button {
-  color: white;
-}
-
-.actionbox > Button:hover {
-  color: white;
-  background-color: #920916;
-}
-
-.close_icon {
-  font-size: 16px;
-  font-weight: bold;
-  line-height: 1;
+.toast_details_button {
+  position: relative;
+  bottom: 0.5rem;
+  font-size: 0.8rem;
 }

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -1,5 +1,6 @@
 .container_toast {
   display: flex;
+  flex-direction: column;
   background-color: rgba(190, 30, 45, 0.8);
   width: 284px;
   cursor: default;
@@ -9,24 +10,20 @@
   bottom: 1rem;
   z-index: 10000;
   box-sizing: border-box;
-  display: inline-flex;
   align-items: center;
-  padding: 0.5rem;
+  justify-content: center;
   border-radius: 5px;
+}
+
+.container_toast_message{
+  display: flex;
   justify-content: center;
 }
+
 
 /* Toast Close Button */
 .toast_close {
   display: flex;
-  cursor: pointer;
-  color: #fff;
-  justify-content: center;
-  align-items: center;
-  padding: 0 0 0 0;
-  margin: 0 0 0 20px;
-  line-height: 16px;
-  border-radius: 5px;
 }
 
 .toast_close:hover {
@@ -37,19 +34,17 @@
   display: flex;
   color: #ffffff;
   text-align: center;
+  padding: 0.5rem;
 }
 
 .actionbox {
   display: flex;
-  flex: 0;
-  justify-content: "flex-start";
-  align-items: end;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0.1rem 0.35rem 0 0.35rem;
+  color: #fff;
 }
 
-.actionbox > div {
-  margin-bottom: 40px;
-  margin-left: 0px;
-}
 
 .actionbox > Button {
   color: white;

--- a/src/src/errordisplay.module.css
+++ b/src/src/errordisplay.module.css
@@ -1,16 +1,6 @@
-.bottom-right {
-  bottom: 12px;
-  right: 12px;
-  transition: transform 0.6s ease-in-out;
-  animation: toast-in-right 0.7s;
-}
-
-.errortoast {
-  position: fixed;
+.toasts_container {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   bottom: 1rem;
-  z-index: 10000;
-  margin-left: 1rem;
-  margin-right: 1rem;
-  display: block;
-  width: 100%;
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1969 

# Additional Review Notes
A bit above and beyond, but I did not like our current stacked rendering of errors.
I am not happy with the management of transitions and would like inputs, as the current Toast-code is a bit messy.

# Changes in this PR
* Toasts take an optional `details` property.
* Toasts with a detail property has a 'details'-button which opens a modal with the content of the details-property.
* Toasts are displayed in a list, instead of stacked on top of one another.
* Toasts fade in, fade out, and slide nicely down the list.
* Toasts are styled slightly nice (IMO).
* Cleanup of the styles used, as a lot of them were unnecessary.

# Future work
* Toasts could offer different ways of rendering complext data in the details Modal.
* Absolute elements (like our toasts) does not work well with z-index and thus some elements hide the toasts (this is partly solved with a proper table library).
* We still spawn way too many errors initially and not on further request-issues -- this is not what I would expect to happen in our case.
* Errors are managed in a single list and never removed from it again. Is this what we want?

Do we want any of these on the board?