### PR TITLE
Initial ECR frontend with mock data

### DIFF
--- a/src/src/App.js
+++ b/src/src/App.js
@@ -7,6 +7,7 @@ import FrontPage from "./pages/frontpage";
 import TopicsPage from "./pages/topics";
 import CapabilitiesPage from "./pages/capabilities";
 import CapabilityDetailsPage from "./pages/capabilities/details";
+import ECRPage from "./pages/ecr";
 
 import { AuthenticatedTemplate } from "@azure/msal-react";
 
@@ -48,6 +49,7 @@ export default function App() {
           <Route index element={<FrontPage />} />
           <Route path="topics" element={<TopicsPage />} />
           <Route path="capabilities" element={<CapabilitiesPage />} />
+          <Route path="ecr" element={<ECRPage />} />
           <Route path="capabilities/:id" element={<CapabilityDetailsPage />} />
         </Route>
       </Routes>

--- a/src/src/components/GlobalMenu/GlobalMenu.jsx
+++ b/src/src/components/GlobalMenu/GlobalMenu.jsx
@@ -25,6 +25,10 @@ export default function GlobalMenu() {
       url: "/topics",
     },
     {
+      title: "ECR",
+      url: "/ecr",
+    },
+    {
       title: "Playbooks",
       url: "https://wiki.dfds.cloud/playbooks",
     },

--- a/src/src/pages/ecr/ECRContext.js
+++ b/src/src/pages/ecr/ECRContext.js
@@ -1,0 +1,74 @@
+import React, { createContext, useEffect, useState } from "react";
+import * as repositoriesApiClient from "./dummyClient";
+import { add, set } from "date-fns";
+
+const ECRContext = createContext();
+
+function ECRProvider({ children }) {
+  //const { repositoriesClient } = useContext(AppContext);
+  const [selectedRepository, setSelectedRepository] = useState(null);
+  const [repositories, setRepositories] = useState([]);
+  const [showNewRepositoryDialog, setShowNewRepositoryDialog] = useState(false);
+  const [isCreatingNewRepository, setIsCreatingNewRepository] = useState(false);
+  const [pollForUpdates, setPollForUpdates] = useState(true);
+  
+  const fetchRepositories = async () => {
+    const result = await repositoriesApiClient.getRepositories();
+    let stopPolling = true;
+    result.forEach((repo) => {
+      if (repo.status === "pending") {
+        stopPolling = false;
+      }
+    });
+    console.log("Continue polling: " + !stopPolling);
+    setPollForUpdates(!stopPolling);
+    console.log("Setting repositories to: " + result.length + " items.");
+    console.log(result);
+    setRepositories(result);
+  };
+
+  const addRepository = async (repository) => {
+    await repositoriesApiClient.addRepository(repository);
+  }
+
+  const toggleSelectedRepository = (repositoryId) => {
+    setSelectedRepository((prev) => {
+      if (prev === repositoryId) {
+        return null;
+      }
+      return repositoryId;
+    });
+  };
+
+  const state = {
+    repositories,
+    selectedRepository,
+    toggleSelectedRepository,
+    addRepository,
+    showNewRepositoryDialog,
+    setShowNewRepositoryDialog,
+    isCreatingNewRepository,
+    setIsCreatingNewRepository,
+    setPollForUpdates
+  };
+
+  /*useEffect(() => {
+    fetchRepositories();
+  }, []);*/
+
+  useEffect(() => {
+    if (pollForUpdates) {
+        const interval = setInterval(() => {
+            console.log("Polling...")
+            fetchRepositories()
+        }, 2000);
+        return () => clearInterval(interval);
+    }
+  }, [pollForUpdates]);
+
+  return (
+    <ECRContext.Provider value={state}>{children}</ECRContext.Provider>
+  );
+}
+
+export { ECRContext as default, ECRProvider };

--- a/src/src/pages/ecr/NewRepositoryDialog.js
+++ b/src/src/pages/ecr/NewRepositoryDialog.js
@@ -1,0 +1,127 @@
+import React, { useState, useContext } from "react";
+import { Button, ButtonStack } from "@dfds-ui/react-components";
+import { SideSheet, SideSheetContent } from "@dfds-ui/react-components";
+import { TextField } from "@dfds-ui/react-components";
+import ECRContext from "./ECRContext";
+
+export default function NewRepositoryDialog({
+  onClose
+}) {
+  const {
+    addRepository,
+    setIsCreatingNewRepository,
+    setPollForUpdates,
+    isCreatingNewRepository
+  } = useContext(ECRContext);
+
+  const handleClose = () => {
+    if (!isCreatingNewRepository) {
+      onClose();
+    }
+  };
+
+  //error banner logic
+  //const displayConflictWarning =
+
+  const emptyValues = {
+    name: "",
+    description: "",
+  };
+
+  const [formData, setFormData] = useState(emptyValues);
+
+  const changeName = (e) => {
+    e.preventDefault();
+    let newName = e?.target?.value || "";
+    newName = newName.replace(/\s+/g, "/");
+
+    setFormData((prev) => ({ ...prev, ...{ name: newName.toLowerCase() } }));
+  };
+
+  const changeDescription = (e) => {
+    e.preventDefault();
+    const newValue = e?.target?.value || emptyValues.description;
+    setFormData((prev) => ({ ...prev, ...{ description: newValue } }));
+  };
+
+  const isNameValid =
+    formData.name !== "" &&
+    !formData.name.match(/^\s*$/g) &&
+    !formData.name.match(/(_|-|\/)$/g) &&
+    !formData.name.match(/^(_|-|\/)/g) &&
+    !formData.name.match(/[-_\/\.]{2,}/g) &&
+    !formData.name.match(/[^a-zA-Z0-9\/\-_]/g);
+
+  let nameErrorMessage = "";
+  if (formData.name.length > 0 && !isNameValid) {
+    nameErrorMessage =
+      'Allowed characters are a-z, 0-9, "-", "_", and "/". Names must not start or end with "_", "-", or "/". Do not use more than one of "-", "_", or "/" in a row.';
+  }
+  if (formData.name.length > 150) {
+    nameErrorMessage = "Please consider a shorter name.";
+  }
+
+  const canAdd =
+    formData.name !== "" &&
+    formData.description !== "" &&
+    nameErrorMessage === "";
+
+  const handleAddRepositoryClicked = async () => {
+    setIsCreatingNewRepository(true);
+    await addRepository(formData);
+    setPollForUpdates(true);
+    setIsCreatingNewRepository(false);
+    onClose();
+  };
+
+  return (
+    <>
+      <SideSheet
+        header={`Add new Repository`}
+        onRequestClose={handleClose}
+        isOpen={true}
+        width="30%"
+        alignSideSheet="right"
+        variant="elevated"
+        backdrop
+      >
+        <SideSheetContent>
+          <div>
+            <TextField
+              label="Name"
+              placeholder="Enter name of capability"
+              required
+              value={formData.name}
+              onChange={changeName}
+              errorMessage={nameErrorMessage}
+              maxLength={255}
+            />
+          </div>
+
+          <TextField
+            label="Description"
+            placeholder="Enter a description"
+            required
+            value={formData.description}
+            onChange={changeDescription}
+          ></TextField>
+
+          <ButtonStack>
+            <Button
+              size="small"
+              variation="primary"
+              onClick={handleAddRepositoryClicked}
+              disabled={!canAdd}
+              submitting={isCreatingNewRepository}
+            >
+              Add
+            </Button>
+            <Button size="small" variation="outlined" onClick={handleClose}>
+              Cancel
+            </Button>
+          </ButtonStack>
+        </SideSheetContent>
+      </SideSheet>
+    </>
+  );
+}

--- a/src/src/pages/ecr/dummyClient.js
+++ b/src/src/pages/ecr/dummyClient.js
@@ -1,0 +1,38 @@
+// Mocking a client with unknown definition.
+
+// Repositories contains: name, description, uri, createdAt, createdBy, status
+let repositoriesData = [
+    {"id": 1, "name": "test-repo-1", "description": "This is a test 1", "uri": "uri://test-repo-1", "createdAt": "24-12-2000 00:00:00", "createdBy": "test-user-1", "status": "active"},
+    {"id": 2, "name": "test-repo-2", "description": "This is a test 2", "uri": "uri://test-repo-2", "createdAt": "24-12-2000 00:00:00", "createdBy": "test-user-2", "status": "active"},
+    {"id": 3, "name": "test-repo-3", "description": "This is a test 3", "uri": "uri://test-repo-3", "createdAt": "24-12-2000 00:00:00", "createdBy": "test-user-3", "status": "active"},
+];
+
+
+const finalizeCreation = (id) => {
+    const repository = repositoriesData.find((repo) => repo.id === id);
+    if (repository) {
+        repository.status = "active";
+        repository.uri = `uri://${repository.name}`;    
+    }
+};
+
+export const getRepositories = async () => {
+    console.log("Returning repositories: " + repositoriesData.length + " items.")
+    return repositoriesData;
+};
+
+// createRepositoryDto contains: name, description, createdBy
+export const addRepository = async (createRepositoryDto) => {
+    const newid = repositoriesData.length + 1;
+    const repository = {
+        ...createRepositoryDto,
+        id: newid,
+        createdAt: new Date().toISOString(),
+        status: "pending",
+    };
+    repositoriesData.push(repository);
+    setTimeout(() => { // fake some latency
+        console.log("Finalizing creation...");
+        finalizeCreation(newid);
+    }, 7000);
+};

--- a/src/src/pages/ecr/ecr.module.css
+++ b/src/src/pages/ecr/ecr.module.css
@@ -1,0 +1,4 @@
+.pendingRow {
+    background-color: #ccc;
+    color: #777;
+}

--- a/src/src/pages/ecr/index.js
+++ b/src/src/pages/ecr/index.js
@@ -1,0 +1,128 @@
+import React, { useEffect, useState, useContext } from "react";
+import {
+  Card,
+  CardTitle,
+  CardContent,
+  CardActions,
+  Button,
+  Table,
+  TableBody,
+  TableDataCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Spinner, 
+} from "@dfds-ui/react-components"; 
+import Page from "components/Page";
+import PageSection from "components/PageSection";
+import ECRContext from "./ECRContext";
+import AppContext from "AppContext";
+import { ECRProvider } from "./ECRContext";
+import NewRepositoryDialog from "./NewRepositoryDialog";
+import styles from "./ecr.module.css";
+
+
+function Repositories() {
+  const { repositories } = useContext(ECRContext);
+  const { truncateString } = useContext(AppContext);
+
+  useEffect(() => {
+    console.log("Repositories updated: ", repositories.length);
+  }, [repositories]);
+
+  /*
+  {repositories.map((repository) => (
+    <Card key={repository.id}>{repository.id} [{repository.status}] -- {repository.name}</Card>
+  ), repositories)}
+*/
+  const rowClass = (status) => status === "pending" ? styles.pendingRow : '';
+
+  return (
+    <>
+      <PageSection headline={`Repositories`}>
+      {((repositories || []).length === 0) && (<Spinner />)}
+      {(repositories.length > 0) && (
+          <>
+            <Table isInteractive width={"100%"}>
+              <TableHead>
+                <TableRow>
+                  <TableHeaderCell>Name</TableHeaderCell>
+                  <TableHeaderCell align="center">URI</TableHeaderCell>
+                  <TableHeaderCell align="center">Note</TableHeaderCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {repositories.map((repository) => (
+                  <TableRow key={repository.id} className={rowClass(repository.status)}>
+                    <TableDataCell>
+                      <Text styledAs="action" as={"div"}>
+                        {truncateString(repository.name)}
+                      </Text>
+                      <Text styledAs="caption" as={"div"}>
+                        {truncateString(repository.description)}
+                      </Text>
+                    </TableDataCell>
+                    <TableDataCell>
+                        <Text styledAs="action" as={"div"}>
+                            {repository.uri}
+                        </Text>
+                    </TableDataCell>
+                    <TableDataCell>
+                      {(repository.status === "pending") && (
+                        <Text styledAs="caption" as={"div"}>
+                          Pending creation
+                        </Text>
+                      )}
+                    </TableDataCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </PageSection>
+    </>
+  );
+}
+
+
+export default function ECRPage() {
+  const [showNewRepositoryDialog, setShowNewRepositoryDialog] = useState(false);
+
+  return (
+    <>
+      <ECRProvider>
+        <Page title="ECR Repositories">
+          {showNewRepositoryDialog && (<NewRepositoryDialog
+            onClose={() => setShowNewRepositoryDialog(false)}
+          />)}
+          <Card
+            variant="fill"
+            surface="main"
+            size="xl"
+            reverse={true}
+          >
+            <CardTitle largeTitle>Information</CardTitle>
+            <CardContent>
+              <p>
+                This is a long text about ECR Repositories. We have no idea what
+                goes here and it is just a placeholder. However, if it is too short
+                then the layout will be all wrong. Long live Lorem Ipsum and all that.
+              </p>
+            </CardContent>
+            <CardActions>
+            <Button
+              size="small"
+              onClick={() => setShowNewRepositoryDialog(true)}
+            >
+              New repository
+            </Button>
+          </CardActions>
+          </Card>
+          <Repositories />
+        </Page>
+      </ECRProvider>
+    </>
+  );
+}


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2006

# Additional Review Notes
This is a very rudimentary, but fully functional version of an ECR frontend allowing users to see existing repositories and add new ones.

Styling is not perfect at all, and I did not add search, as I do want to wait for the new table-style for that.

However, it should be quite easy to hook this up to a real API and get rid of the current dummy implementation.
Some attribute and variable names might need an update though.
