### PR TITLE
Layer splash image underneath popups

### DIFF
--- a/src/src/pages/capabilities/capabilities.module.css
+++ b/src/src/pages/capabilities/capabilities.module.css
@@ -36,3 +36,12 @@
 .deletedRow {
   background-color: #d88;
 }
+
+.cardMediaImage {
+  position: unset!important;
+  float: right;
+}
+
+.cardMedia {
+  position: unset!important;
+}

--- a/src/src/pages/capabilities/index.js
+++ b/src/src/pages/capabilities/index.js
@@ -13,7 +13,7 @@ import NewCapabilityDialog from "./NewCapabilityDialog";
 import MyCapabilities from "./MyCapabilities";
 import OtherCapabilities from "./OtherCapabilities";
 import Page from "components/Page";
-import SpashImage from "./splash.jpg";
+import SplashImage from "./splash.jpg";
 
 export default function CapabilitiesPage() {
   const { addNewCapability } = useContext(AppContext);
@@ -28,7 +28,7 @@ export default function CapabilitiesPage() {
   };
 
   const splash = (
-    <CardMedia aspectRatio="3:2" media={<img src={SpashImage} alt="" />} />
+    <CardMedia aspectRatio="3:2" media={<img src={SplashImage} className={styles.cardMediaImage} alt=""/>} className={styles.cardMedia} />
   );
 
   return (

--- a/src/src/pages/topics/index.js
+++ b/src/src/pages/topics/index.js
@@ -182,7 +182,7 @@ function Topics() {
 
 export default function TopicsPage() {
   const splash = (
-    <CardMedia aspectRatio="3:2" media={<img src={topicImage} alt="" />} />
+    <CardMedia aspectRatio="3:2" media={<img src={topicImage} alt="" className={styles.cardMediaImage} />} className={styles.cardMedia} />
   );
 
   return (

--- a/src/src/pages/topics/topic.module.css
+++ b/src/src/pages/topics/topic.module.css
@@ -21,3 +21,12 @@
 .checkboxes > label {
   margin-right: 19px;
 }
+
+.cardMediaImage {
+  position: unset!important;
+  float: right;
+}
+
+.cardMedia {
+  position: unset!important;
+}


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2043

# Additional Review Notes
I am not happy about repeating stylings, but even in this case global stylings seem worse.
Neither am I happy with how the styling is currently set up, making this hack necessary, but fixing the DFDS frontend library is a massive task that could have more conequences than we want to deal with.
Lastly; using `!important` is a faux pas, but here we go -- it seems necessary here, unfortunately.


