### PR TITLE
Bug/2090 menu folding with longer names

### DIFF
--- a/src/src/AppContext.js
+++ b/src/src/AppContext.js
@@ -5,6 +5,7 @@ import { useLatestNews } from "hooks/LatestNews";
 import ErrorContext from "./ErrorContext";
 import { useCapabilities } from "hooks/Capabilities";
 import { MetricsWrapper } from "./MetricsWrapper";
+import { useMsal } from "@azure/msal-react";
 
 const AppContext = React.createContext(null);
 
@@ -53,6 +54,17 @@ function AppProvider({ children }) {
   );
 
   const { addCapability } = useCapabilities();
+
+  const { instance } = useMsal();
+  const handleLogout = () => {
+    instance.logoutRedirect()
+      .then(response => {
+        console.log('Logout successful', response);
+      })
+      .catch(error => {
+        console.error('Logout failed', error);
+      });
+  };
 
   async function addNewCapability(name, description) {
     addCapability(name, description);
@@ -140,6 +152,7 @@ function AppProvider({ children }) {
     addCapability,
     addNewCapability,
     truncateString,
+    handleLogout,
   };
 
   return <AppContext.Provider value={state}>{children}</AppContext.Provider>;

--- a/src/src/AppContext.js
+++ b/src/src/AppContext.js
@@ -5,7 +5,6 @@ import { useLatestNews } from "hooks/LatestNews";
 import ErrorContext from "./ErrorContext";
 import { useCapabilities } from "hooks/Capabilities";
 import { MetricsWrapper } from "./MetricsWrapper";
-import { useMsal } from "@azure/msal-react";
 
 const AppContext = React.createContext(null);
 
@@ -54,17 +53,6 @@ function AppProvider({ children }) {
   );
 
   const { addCapability } = useCapabilities();
-
-  const { instance } = useMsal();
-  const handleLogout = () => {
-    instance.logoutRedirect()
-      .then(response => {
-        console.log('Logout successful', response);
-      })
-      .catch(error => {
-        console.error('Logout failed', error);
-      });
-  };
 
   async function addNewCapability(name, description) {
     addCapability(name, description);
@@ -152,7 +140,6 @@ function AppProvider({ children }) {
     addCapability,
     addNewCapability,
     truncateString,
-    handleLogout,
   };
 
   return <AppContext.Provider value={state}>{children}</AppContext.Provider>;

--- a/src/src/components/GlobalMenu/GlobalMenu.jsx
+++ b/src/src/components/GlobalMenu/GlobalMenu.jsx
@@ -5,12 +5,15 @@ import {
   AppBarProvider,
   AppBarDrawer,
   AppBarItem,
+  AppBarIconButton,
   AppBarListItem,
+  MenuPopOverContext,
   ListText,
 } from "@dfds-ui/react-components";
+import { Account } from '@dfds-ui/icons/system'
 import { SmallProfilePicture as ProfilePicture } from "components/ProfilePicture";
-import ProfileName from "./ProfileName";
 import AppContext from "AppContext";
+import styles from "./GlobalMenu.module.css";
 
 export default function GlobalMenu() {
   const { user } = useContext(AppContext);
@@ -52,27 +55,48 @@ export default function GlobalMenu() {
           leftActions={<></>}
           actions={
             <>
-              {/* <AppBarIconButton icon={Search} ariaLabel="Search" /> */}
-              <AppBarItem title="Name" id="profile-name" as={ProfileName} />
               <AppBarItem
-                title="Profile"
                 id="profile"
-                as={ProfilePicture}
-                name={user.name ?? ""}
-                pictureUrl={user.profilePictureUrl ?? ""}
-              />
+                Icon={Account}
+                title="Profile"
+                //as={ProfilePicture}
+                //pictureUrl={user.profilePictureUrl ?? ""}
+                placement="bottom-end"
+              >
+                <MenuPopOverContext.Consumer>
+                  {(context) => {
+                    return (
+                      <>
+                        <AppBarListItem>
+                          <ListText><span><b>{user.name ?? "<noname>"}</b><br/>{user.title ?? "<untitled>"}</span></ListText>
+                        </AppBarListItem>
+                        
+                        <AppBarListItem
+                          clickable
+                          onClick={() => {
+                            alert("Logout not implemented")
+                            context.handlePopoverClose()
+                          }}
+                        >
+                          <ListText>Logout</ListText>
+                        </AppBarListItem>
+                      </>
+                    )
+                  }}
+                </MenuPopOverContext.Consumer>
+              </AppBarItem>
             </>
           }
         >
           {navLinks.map((x) =>
             /https:?\/\//.test(x.url) ? (
-              <a href={x.url} style={{ textDecoration: "none" }} key={x.title}>
+              <a href={x.url} style={{ textDecoration: "none" }} key={x.title} className={styles.alignCenter}>
                 <AppBarListItem clickable>
                   <ListText>{x.title}</ListText>
                 </AppBarListItem>
               </a>
             ) : (
-              <Link to={x.url} style={{ textDecoration: "none" }} key={x.title}>
+              <Link to={x.url} style={{ textDecoration: "none" }} key={x.title} className={styles.alignCenter}>
                 <AppBarListItem clickable>
                   <ListText>{x.title}</ListText>
                 </AppBarListItem>

--- a/src/src/components/GlobalMenu/GlobalMenu.jsx
+++ b/src/src/components/GlobalMenu/GlobalMenu.jsx
@@ -76,7 +76,7 @@ export default function GlobalMenu() {
                           />
                         </AppBarListItem>
                         
-                        <AppBarListItem
+                        {/*<AppBarListItem
                           clickable
                           onClick={() => {
                             handleLogout();
@@ -85,6 +85,7 @@ export default function GlobalMenu() {
                         >
                           <ListText>Logout</ListText>
                         </AppBarListItem>
+                        */}
                       </>
                     )
                   }}

--- a/src/src/components/GlobalMenu/GlobalMenu.jsx
+++ b/src/src/components/GlobalMenu/GlobalMenu.jsx
@@ -16,7 +16,7 @@ import AppContext from "AppContext";
 import styles from "./GlobalMenu.module.css";
 
 export default function GlobalMenu() {
-  const { user } = useContext(AppContext);
+  const { user, handleLogout } = useContext(AppContext);
 
   const navLinks = [
     {
@@ -59,8 +59,6 @@ export default function GlobalMenu() {
                 id="profile"
                 Icon={Account}
                 title="Profile"
-                //as={ProfilePicture}
-                //pictureUrl={user.profilePictureUrl ?? ""}
                 placement="bottom-end"
               >
                 <MenuPopOverContext.Consumer>
@@ -69,13 +67,20 @@ export default function GlobalMenu() {
                       <>
                         <AppBarListItem>
                           <ListText><span><b>{user.name ?? "<noname>"}</b><br/>{user.title ?? "<untitled>"}</span></ListText>
+                          <ProfilePicture
+                            clickable
+                            as={AppBarItem}
+                            title="Profile"
+                            pictureUrl={user.profilePictureUrl ?? ""}
+                            placement="bottom-end"
+                          />
                         </AppBarListItem>
                         
                         <AppBarListItem
                           clickable
                           onClick={() => {
-                            alert("Logout not implemented")
-                            context.handlePopoverClose()
+                            handleLogout();
+                            //context.handlePopoverClose();
                           }}
                         >
                           <ListText>Logout</ListText>

--- a/src/src/components/GlobalMenu/GlobalMenu.jsx
+++ b/src/src/components/GlobalMenu/GlobalMenu.jsx
@@ -16,7 +16,7 @@ import AppContext from "AppContext";
 import styles from "./GlobalMenu.module.css";
 
 export default function GlobalMenu() {
-  const { user, handleLogout } = useContext(AppContext);
+  const { user } = useContext(AppContext);
 
   const navLinks = [
     {
@@ -75,17 +75,6 @@ export default function GlobalMenu() {
                             placement="bottom-end"
                           />
                         </AppBarListItem>
-                        
-                        {/*<AppBarListItem
-                          clickable
-                          onClick={() => {
-                            handleLogout();
-                            //context.handlePopoverClose();
-                          }}
-                        >
-                          <ListText>Logout</ListText>
-                        </AppBarListItem>
-                        */}
                       </>
                     )
                   }}

--- a/src/src/components/GlobalMenu/GlobalMenu.module.css
+++ b/src/src/components/GlobalMenu/GlobalMenu.module.css
@@ -1,0 +1,5 @@
+.alignCenter {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/src/src/hooks/Topics.js
+++ b/src/src/hooks/Topics.js
@@ -25,7 +25,6 @@ export function useTopics() {
         copy.kafkaClusterName = found?.name || "";
         return copy;
       });
-      console.log(finalTopics);
       setTopicsList(finalTopics);
       setIsLoaded(true);
     }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2090

# Additional Review Notes
Suggested change is not perfect, but works.
I would have preferred to use the Profile Picture as the button in the corner, but this is hard to do with our DFDS components.

Due to the way MSAL works, this logout will clear the local storage even if the user does not select an account to logout from.
This is a known issue, but I am up for suggestions on how to fix it.

![image](https://github.com/dfds/selfservice-portal/assets/177252/51031ba7-90ba-4a22-87f2-bca1924f68f9)
