### PR TITLE
Feature/2074 details section in frontend error banner

### DIFF
--- a/src/src/ErrorContext.js
+++ b/src/src/ErrorContext.js
@@ -1,17 +1,28 @@
 import ErrorDisplay from "ErrorDisplay";
 import React, { createContext, useEffect, useState } from "react";
 
+class ErrorContent {
+    msg = null;
+    details = null;
+    constructor(msg, details) {
+        this.msg = msg;
+        this.details = details;
+    }
+}
+
 const ErrorContext = createContext();
 
 function ErrorProvider({ children }) {
-  const [error, setError] = useState([]);
+  const [errors, setErrors] = useState([]);
 
-  const showError = (errorMessage) => {
-    setError((prevError) => [...prevError, errorMessage])
+  const showError = (errorMessage, errorDetails=null) => {
+    console.log("adding new error with msg: ", errorMessage);
+    const error = new ErrorContent(errorMessage, errorDetails);
+    setErrors((prevError) => [...prevError, error])
   };
 
   return (
-    <ErrorContext.Provider value={{ error, showError }}>
+    <ErrorContext.Provider value={{ errors, showError }}>
       {<ErrorDisplay />}
       {children}
     </ErrorContext.Provider>

--- a/src/src/ErrorContext.js
+++ b/src/src/ErrorContext.js
@@ -16,7 +16,7 @@ function ErrorProvider({ children }) {
   const [errors, setErrors] = useState([]);
 
   const showError = (errorMessage, errorDetails=null) => {
-    console.log("adding new error with msg: ", errorMessage);
+    // console.log("adding new error with msg: ", errorMessage); //leaving this here for debugging inb4 comment on PR
     const error = new ErrorContent(errorMessage, errorDetails);
     setErrors((prevError) => [...prevError, error])
   };

--- a/src/src/ErrorDisplay.js
+++ b/src/src/ErrorDisplay.js
@@ -12,7 +12,6 @@ const ErrorDisplay = () => {
     <div className={styles.toasts_container}>
       {errors.map((e, index) => (
         <>
-        {console.log("going to display error: ", e)}
         <Toast key={index} message={e.msg} details={e.details ? e.details : null}></Toast>
         </>
       ))}

--- a/src/src/ErrorDisplay.js
+++ b/src/src/ErrorDisplay.js
@@ -4,17 +4,16 @@ import Toast from "components/Toast/index.js";
 import styles from "errordisplay.module.css"
 
 const ErrorDisplay = () => {
-  const { error } = useContext(ErrorContext);
-
-  if (error.length === 0) {
+  const { errors } = useContext(ErrorContext); //error is multiple errors
+  if (errors.length === 0) {
     return null;
   }
-
   return (
     <div className={styles.toasts_container}>
-      {error.map((e, index) => (
+      {errors.map((e, index) => (
         <>
-        <Toast key={index} message={e}></Toast>
+        {console.log("going to display error: ", e)}
+        <Toast key={index} message={e.msg} details={e.details ? e.details : null}></Toast>
         </>
       ))}
     </div>

--- a/src/src/SelfServiceApiClient.js
+++ b/src/src/SelfServiceApiClient.js
@@ -437,7 +437,6 @@ export class SelfServiceApiClient {
     this.responseHandler(response);
 
     if (!response.ok) {
-      console.log("response was: ", response.status);
       return [];
     }
 

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -69,7 +69,11 @@ export default function Toast({ message, details }) {
         actions={actions}
     >
       {console.log("details in component: ", details)}
-      {details ? <div>{''+details}</div> : "No details available"}
+      {details ? <div>{'Got '+details.status+': "'+details.statusText+'" for '+details.url+'.'
+                      }
+                  </div>
+               : "No details available"
+      }
     </Modal>)}
     {showToast && (
     <div className={`${styles.toast_container} ${hide ? styles.hidden : ''}`} style={{"opacity": opacity}}>

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -22,7 +22,7 @@ export default function Toast({ message, details }) {
   const prevOpacity = usePrevious(opacity);
   const [hide, setHide] = useState(false);
   const prevHide = usePrevious(hide);
- 
+
   const actions = (
     <>
       <ModalAction
@@ -68,7 +68,8 @@ export default function Toast({ message, details }) {
         onRequestClose={() => setShowDetails(false)}
         actions={actions}
     >
-      {details ? details : "No details available"}
+      {console.log("details in component: ", details)}
+      {details ? <div>{''+details}</div> : "No details available"}
     </Modal>)}
     {showToast && (
     <div className={`${styles.toast_container} ${hide ? styles.hidden : ''}`} style={{"opacity": opacity}}>
@@ -80,7 +81,6 @@ export default function Toast({ message, details }) {
         <div className={styles.toast_message}>
           {message}
         </div>
-        <br />
         {details && (
         <div>
           <Button size="small" variation="link" fillWidth="true" onClick={() => setShowDetails(true)}>

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -1,4 +1,5 @@
 .toast_container {
+  position: relative;
   background-color: rgba(190, 30, 45);
   width: 284px;
   border-radius: 5px;
@@ -40,6 +41,13 @@
 
 .toast_details_button {
   position: relative;
-  bottom: 0.5rem;
+  bottom: 0.7rem; /* Adjust as needed */
+  transform: translateX(-50%);
   font-size: 0.8rem;
+  color: #6d6d6d; /* Adjust to match your design */
+  cursor: pointer; /* Indicates an interactive element */
+}
+
+.toast_details_button:hover {
+  color: rgb(255, 255, 255); /* Change the color upon hover */
 }

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -41,13 +41,13 @@
 
 .toast_details_button {
   position: relative;
-  bottom: 0.7rem; /* Adjust as needed */
+  bottom: 0.7rem;
   transform: translateX(-50%);
   font-size: 0.8rem;
-  color: #6d6d6d; /* Adjust to match your design */
-  cursor: pointer; /* Indicates an interactive element */
+  color: #6d6d6d;
+  cursor: pointer;
 }
 
 .toast_details_button:hover {
-  color: rgb(255, 255, 255); /* Change the color upon hover */
+  color: rgb(255, 255, 255);
 }

--- a/src/src/hooks/Error.js
+++ b/src/src/hooks/Error.js
@@ -29,12 +29,14 @@ export function useError(opts) {
     // Error handling flow
     if (params?.handler != null) {
       // 1: Handler provided via params
+      console.log("hit prio #1");
       params.handler(params);
       return;
     }
 
     if (options?.handler != null) {
       // 2: Handler provided via options
+      console.log("hit prio #2");
       if (params.msg === null) {
         params.msg = fallbackMsg;
       }
@@ -44,19 +46,21 @@ export function useError(opts) {
 
     if (params) {
       if (params.error) {
+      console.log("hit prio #3");
         // 3: Error provided via params
-        showError(params.error.message);
+        showError(params.error.message, params.details);
         return;
       }
 
       if (params.msg) {
         // 4: Msg provided via params
-        showError(params.msg);
+      console.log("hit prio #4");
+        showError(params.msg, params.details);
         return;
       }
     }
 
-    showError(fallbackMsg); // 5: fallbackMsg
+    showError(fallbackMsg, params.httpResponse); // 5: fallbackMsg
   };
 
   return {

--- a/src/src/hooks/Error.js
+++ b/src/src/hooks/Error.js
@@ -29,14 +29,12 @@ export function useError(opts) {
     // Error handling flow
     if (params?.handler != null) {
       // 1: Handler provided via params
-      console.log("hit prio #1");
       params.handler(params);
       return;
     }
 
     if (options?.handler != null) {
       // 2: Handler provided via options
-      console.log("hit prio #2");
       if (params.msg === null) {
         params.msg = fallbackMsg;
       }
@@ -46,7 +44,6 @@ export function useError(opts) {
 
     if (params) {
       if (params.error) {
-      console.log("hit prio #3");
         // 3: Error provided via params
         showError(params.error.message, params.details);
         return;
@@ -54,7 +51,6 @@ export function useError(opts) {
 
       if (params.msg) {
         // 4: Msg provided via params
-      console.log("hit prio #4");
         showError(params.msg, params.details);
         return;
       }

--- a/src/src/misc/error.js
+++ b/src/src/misc/error.js
@@ -8,6 +8,7 @@ class ErrorContext {
   error = null;
   msg = null;
   handler = null;
+  details = null;
   showError = null;
 }
 
@@ -31,6 +32,11 @@ class ErrorContextBuilder {
 
   setHandler(input) {
     this.val.handler = input;
+    return this;
+  }
+
+  setDetails(input) {
+    this.val.details = input;
     return this;
   }
 


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2074

# Additional Review Notes
"V1" of how details are to be handled in the error banner.
Two things are still not finalized because the best (or least worst) way to handle them will be determined through use of the portal; these are:
- cosmetic design of the details button and modal (less important)
- the way the error context's logic is used to handle http and other types of errors: should a banner be triggered for all types of error? If so, what should the details be for errors other than http?
