### PR TITLE
disabled kafka cluster access for now

### DIFF
--- a/src/src/pages/capabilities/KafkaCluster/index.js
+++ b/src/src/pages/capabilities/KafkaCluster/index.js
@@ -316,14 +316,21 @@ export default function KafkaCluster({ cluster, capabilityId }) {
       )}
 
       {canRequestAccess && (
-        <ButtonStack align="right">
-          <Button
+          <ButtonStack align="right">
+            <p>
+              Currently not possible to request access to Kafka clusters. Please
+              see more info here:
+              <a href={"https://dfdsit.statuspage.io/incidents/sryjd688nj5b"}>
+                https://dfdsit.statuspage.io/incidents/sryjd688nj5b
+              </a>
+            </p>
+            {/*  <Button
             size="small"
             submitting={isRequestingAccess}
             onClick={handleRequestAccess}
           >
             Request Access
-          </Button>
+          </Button>*/}
         </ButtonStack>
       )}
     </PageSection>


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2177

# Additional Review Notes
temporary solution until we have fixed confluent cloud issue
