### PR TITLE
feature/2199 create a hook for getkafkaclusteraccesslist

### DIFF
--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -161,3 +161,40 @@ export function useCapabilityMembers(capabilityDefinition) {
     membersList,
   };
 }
+
+export function useKafkaClustersAccessList(capabilityDefinition) {
+  const { inProgress, responseData, setErrorOptions, sendRequest } =
+    useSelfServiceRequest();
+  const [isLoadedClusters, setIsLoadedClusters] = useState(false);
+  const [clustersList, setClustersList] = useState([]);
+
+  const clustersLink = capabilityDefinition?._links?.clusters;
+
+  
+
+  useEffect(() => {
+    if (clustersLink) {
+      sendRequest({
+        urlSegments: [clustersLink.href],
+      });
+    }
+  }, [clustersLink]);
+
+  useEffect(() => {
+    if (responseData?.items.length >= 0) {
+      setClustersList(responseData?.items || []);
+    }
+  }, [responseData]);
+
+  useEffect(() => {
+    if (clustersList.length >= 0) {
+      setIsLoadedClusters(true);
+    }
+  }, [clustersList]);
+
+  return {
+    isLoadedClusters,
+    clustersList,
+  };
+}
+

--- a/src/src/pages/capabilities/SelectedCapabilityContext.js
+++ b/src/src/pages/capabilities/SelectedCapabilityContext.js
@@ -56,7 +56,7 @@ function SelectedCapabilityProvider({ children }) {
   const [showCosts, setShowCosts] = useState(false);
   const { clustersList, isLoadedClusters } = useKafkaClustersAccessList(details);
 
-  useEffect(() => {
+  const kafkaClusterTopicList = () => {
     if (clustersList.length !== 0){
       const promises = [];
       for (const cluster of clustersList) {
@@ -76,11 +76,16 @@ function SelectedCapabilityProvider({ children }) {
 
         Promise.all(promises).then((clusters) => {
           setKafkaClusters(clusters);
-        });      
+        });  
+      }
+    }    
+  
 
-    } 
-
+  useEffect(() => {
+    kafkaClusterTopicList();
   }, [clustersList])
+
+  
 
   // load membership applications
   const loadMembershipApplications = useCallback(async () => {
@@ -353,7 +358,6 @@ function SelectedCapabilityProvider({ children }) {
   useEffect(() => {
     if (details) {
       loadMembershipApplications();
-      // loadKafkaClustersAndTopics();
       loadAwsAccount();
     } else {
       setMembers([]);
@@ -366,7 +370,7 @@ function SelectedCapabilityProvider({ children }) {
   useEffect(() => {
     const handle = setInterval(() => {
       if (details && shouldAutoReloadTopics) {
-        // loadKafkaClustersAndTopics();
+        kafkaClusterTopicList();
       }
     }, 5 * 1000);
 

--- a/src/src/pages/capabilities/SelectedCapabilityContext.js
+++ b/src/src/pages/capabilities/SelectedCapabilityContext.js
@@ -10,6 +10,7 @@ import {
   useCapabilities,
   useCapabilityById,
   useCapabilityMembers,
+  useKafkaClustersAccessList,
 } from "hooks/Capabilities";
 
 import { getAnotherUserProfilePictureUrl } from "../../GraphApiClient";
@@ -53,32 +54,33 @@ function SelectedCapabilityProvider({ children }) {
   const [isPendingDeletion, setPendingDeletion] = useState(null);
   const [isDeleted, setIsDeleted] = useState(null);
   const [showCosts, setShowCosts] = useState(false);
+  const { clustersList, isLoadedClusters } = useKafkaClustersAccessList(details);
 
-  // load kafka clusters and topics
-  const loadKafkaClustersAndTopics = useCallback(async () => {
-    const clusters = await selfServiceApiClient.getKafkaClusterAccessList(
-      details,
-    );
-    let allTopicsProvisioned = true;
-    for (const cluster of clusters) {
-      const topics = await selfServiceApiClient.getTopics(cluster);
+  useEffect(() => {
+    if (clustersList.length !== 0){
+      const promises = [];
+      for (const cluster of clustersList) {
+        let promise = selfServiceApiClient.getTopics(cluster).then((topics) => {
+          topics.forEach((kafkaTopic) => {
+            adjustRetention(kafkaTopic);
+            kafkaTopic.messageContracts = (kafkaTopic.messageContracts || []).sort(
+              (a, b) => a.messageType.localeCompare(b.messageType),
+            );
+          });
 
-      topics.forEach((kafkaTopic) => {
-        if (kafkaTopic.status !== "Provisioned") {
-          allTopicsProvisioned = false;
-        }
-        adjustRetention(kafkaTopic);
-        kafkaTopic.messageContracts = (kafkaTopic.messageContracts || []).sort(
-          (a, b) => a.messageType.localeCompare(b.messageType),
-        );
-      });
+          cluster.topics = topics;
+          return cluster;
+        });
+        promises.push(promise);
+        };
 
-      cluster.topics = topics;
-    }
+        Promise.all(promises).then((clusters) => {
+          setKafkaClusters(clusters);
+        });      
 
-    setShouldAutoReloadTopics(!allTopicsProvisioned);
-    setKafkaClusters(clusters);
-  }, [details]);
+    } 
+
+  }, [clustersList])
 
   // load membership applications
   const loadMembershipApplications = useCallback(async () => {
@@ -351,7 +353,7 @@ function SelectedCapabilityProvider({ children }) {
   useEffect(() => {
     if (details) {
       loadMembershipApplications();
-      loadKafkaClustersAndTopics();
+      // loadKafkaClustersAndTopics();
       loadAwsAccount();
     } else {
       setMembers([]);
@@ -364,7 +366,7 @@ function SelectedCapabilityProvider({ children }) {
   useEffect(() => {
     const handle = setInterval(() => {
       if (details && shouldAutoReloadTopics) {
-        loadKafkaClustersAndTopics();
+        // loadKafkaClustersAndTopics();
       }
     }, 5 * 1000);
 


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2199 

# Additional Review Notes
The useKafkaClustersAccessList has been introduced. It has replaced the old functionality in the SelfServiceApiClient.
