### PR TITLE
Feature/2229 add invitations to capability create form

### DIFF
--- a/src/src/AppContext.js
+++ b/src/src/AppContext.js
@@ -58,7 +58,8 @@ function AppProvider({ children }) {
   const {statsInfo, isLoadedStats} = useStats();
 
   async function addNewCapability(name, description, invitations) {
-    addCapability(name, description, invitations);
+    const invitees = invitations.split(/,\s*/);
+    addCapability(name, description, invitees);
     await sleep(3000);
     await loadMyProfile();
   }

--- a/src/src/AppContext.js
+++ b/src/src/AppContext.js
@@ -57,8 +57,8 @@ function AppProvider({ children }) {
   const {profileInfo, isLoadedProfile} = useProfile();
   const {statsInfo, isLoadedStats} = useStats();
 
-  async function addNewCapability(name, description) {
-    addCapability(name, description);
+  async function addNewCapability(name, description, invitations) {
+    addCapability(name, description, invitations);
     await sleep(3000);
     await loadMyProfile();
   }

--- a/src/src/AppContext.js
+++ b/src/src/AppContext.js
@@ -58,8 +58,7 @@ function AppProvider({ children }) {
   const {statsInfo, isLoadedStats} = useStats();
 
   async function addNewCapability(name, description, invitations) {
-    const invitees = invitations.split(/,\s*/);
-    addCapability(name, description, invitees);
+    addCapability(name, description, invitations);
     await sleep(3000);
     await loadMyProfile();
   }

--- a/src/src/GraphApiClient.js
+++ b/src/src/GraphApiClient.js
@@ -50,14 +50,15 @@ export async function getAnotherUserProfilePictureUrl(upn) {
   return url.createObjectURL(blob);
 }
 
-
 export async function getUsers(filterString) {
   const accessToken = await getGraphAccessToken();
   const adUsers = await callApi(
-    `https://graph.microsoft.com/v1.0/users?$filter=startswith(displayName, '${encodeURIComponent(filterString)}')`,
+    `https://graph.microsoft.com/v1.0/users?$filter=startswith(displayName, '${encodeURIComponent(
+      filterString,
+    )}')`,
     accessToken,
   );
   const users = await adUsers.json();
 
-  return users
+  return users;
 }

--- a/src/src/GraphApiClient.js
+++ b/src/src/GraphApiClient.js
@@ -49,3 +49,15 @@ export async function getAnotherUserProfilePictureUrl(upn) {
 
   return url.createObjectURL(blob);
 }
+
+
+export async function getUsers(filterString) {
+  const accessToken = await getGraphAccessToken();
+  const adUsers = await callApi(
+    `https://graph.microsoft.com/v1.0/users?$filter=startswith(displayName, '${filterString}')`,
+    accessToken,
+  );
+  const users = await adUsers.json();
+
+  return users
+}

--- a/src/src/GraphApiClient.js
+++ b/src/src/GraphApiClient.js
@@ -54,7 +54,7 @@ export async function getAnotherUserProfilePictureUrl(upn) {
 export async function getUsers(filterString) {
   const accessToken = await getGraphAccessToken();
   const adUsers = await callApi(
-    `https://graph.microsoft.com/v1.0/users?$filter=startswith(displayName, '${filterString}')`,
+    `https://graph.microsoft.com/v1.0/users?$filter=startswith(displayName, '${encodeURIComponent(filterString)}')`,
     accessToken,
   );
   const users = await adUsers.json();

--- a/src/src/components/DropDownMenu/dropdownmenu.module.css
+++ b/src/src/components/DropDownMenu/dropdownmenu.module.css
@@ -1,0 +1,16 @@
+.items {
+    display: flex;
+    border: 2px solid #49a2df;
+    flex-direction: column;
+}
+
+.item {
+    display: flex;
+    padding: 4px 4px 2px 4px;
+    user-select: none;
+    cursor: pointer;
+}
+
+.item:hover{
+    background-color: blue;
+}

--- a/src/src/components/DropDownMenu/dropdownmenu.module.css
+++ b/src/src/components/DropDownMenu/dropdownmenu.module.css
@@ -1,16 +1,16 @@
 .items {
-    display: flex;
-    border: 2px solid #49a2df;
-    flex-direction: column;
+  display: flex;
+  border: 2px solid #49a2df;
+  flex-direction: column;
 }
 
 .item {
-    display: flex;
-    padding: 4px 4px 2px 4px;
-    user-select: none;
-    cursor: pointer;
+  display: flex;
+  padding: 4px 4px 2px 4px;
+  user-select: none;
+  cursor: pointer;
 }
 
-.item:hover{
-    background-color: #d9dcde;
+.item:hover {
+  background-color: #d9dcde;
 }

--- a/src/src/components/DropDownMenu/dropdownmenu.module.css
+++ b/src/src/components/DropDownMenu/dropdownmenu.module.css
@@ -12,5 +12,5 @@
 }
 
 .item:hover{
-    background-color: blue;
+    background-color: #d9dcde;
 }

--- a/src/src/components/DropDownMenu/index.js
+++ b/src/src/components/DropDownMenu/index.js
@@ -2,23 +2,31 @@ import React from "react";
 import style from "./dropdownmenu.module.css";
 import ProfilePicture from "pages/capabilities/members/profilepicture";
 
-export default function DropDownMenu({items, setIsUserSearchActive, setInvitationsInput}){
+export default function DropDownMenu({
+  items,
+  setIsUserSearchActive,
+  setInvitationsInput,
+}) {
+  const handleItemClick = (email) => {
+    setIsUserSearchActive(false);
+    setInvitationsInput(email);
+  };
 
-    const handleItemClick = (email) => {
-        setIsUserSearchActive(false);
-        setInvitationsInput(email);
-    }
-
-    return <>
-        <div>
-            <div className={style.items}>
-                {(items || []).map((item) => (
-                <div key={item.id} className={style.item}  onClick={() => handleItemClick(item.mail)}>
-                    {item.displayName} {item.mail}
-                </div>
-                ))}
+  return (
+    <>
+      <div>
+        <div className={style.items}>
+          {(items || []).map((item) => (
+            <div
+              key={item.id}
+              className={style.item}
+              onClick={() => handleItemClick(item.mail)}
+            >
+              {item.displayName} {item.mail}
             </div>
+          ))}
         </div>
+      </div>
     </>
-
-} 
+  );
+}

--- a/src/src/components/DropDownMenu/index.js
+++ b/src/src/components/DropDownMenu/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import style from "./dropdownmenu.module.css";
 import ProfilePicture from "pages/capabilities/members/profilepicture";
 
-export default function DropDownMenu({
+export default function DropDownInvitationsMenu({
   items,
   setIsUserSearchActive,
   setInvitationsInput,

--- a/src/src/components/DropDownMenu/index.js
+++ b/src/src/components/DropDownMenu/index.js
@@ -1,0 +1,24 @@
+import React from "react";
+import style from "./dropdownmenu.module.css";
+import ProfilePicture from "pages/capabilities/members/profilepicture";
+
+export default function DropDownMenu({items, setIsUserSearchActive, setInvitationsInput}){
+
+    const handleItemClick = (email) => {
+        setIsUserSearchActive(false);
+        setInvitationsInput(email);
+    }
+
+    return <>
+        <div>
+            <div className={style.items}>
+                {(items || []).map((item) => (
+                <div key={item.id} className={style.item}  onClick={() => handleItemClick(item.mail)}>
+                    {item.displayName} {item.mail}
+                </div>
+                ))}
+            </div>
+        </div>
+    </>
+
+} 

--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -15,19 +15,21 @@ export function useCapabilities() {
     list.sort((a, b) => a.name.localeCompare(b.name));
   };
 
-  const createCapability = (name, description) => {
+  const createCapability = (name, description, invitations) => {
     addCapability({
       urlSegments: ["capabilities"],
       method: "POST",
       payload: {
         name: name,
         description: description,
+        invitees: invitations,
       },
     });
   };
 
   useEffect(() => {
     if (addedCapability) {
+      console.log(addedCapability);
       setCapabilities((prev) => {
         const list = [...prev, addCapability];
         sortByName(list);

--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -29,7 +29,6 @@ export function useCapabilities() {
 
   useEffect(() => {
     if (addedCapability) {
-      console.log(addedCapability);
       setCapabilities((prev) => {
         const list = [...prev, addCapability];
         sortByName(list);

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -42,7 +42,7 @@ export default function NewCapabilityDialog({
 
   const changeInvitation = (e) => {
     e.preventDefault();
-    const newValue = e?.target?.value.split(/,\s*/) || emptyValues.invitations;
+    const newValue = e?.target?.value || emptyValues.invitations;
     setFormData((prev) => ({ ...prev, ...{ invitations: newValue } }));
   }
 

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -6,10 +6,12 @@ import styles from "./capabilities.module.css";
 import { getUsers } from "GraphApiClient";
 import DropDownMenu from "components/DropDownMenu";
 
-function TextWrapper(){
-  return <>
-  <div className=""></div>
-  </>
+function TextWrapper() {
+  return (
+    <>
+      <div className=""></div>
+    </>
+  );
 }
 
 export default function NewCapabilityDialog({
@@ -35,22 +37,23 @@ export default function NewCapabilityDialog({
   const [formData, setFormData] = useState(emptyValues);
   const [isUserSearchActive, setIsUserSearchActive] = useState(false);
   const [adUsers, setadUsers] = useState([]);
-  const [invitationsInput, setInvitationsInput] = useState("")
+  const [invitationsInput, setInvitationsInput] = useState("");
   const [invitees, setInvitees] = useState([]);
 
   useEffect(() => {
-    if (invitationsInput !== ""){
-      setInvitees((prev) => ( [...prev, invitationsInput]));
-    } 
-    setFormData((prev) => ({ ...prev, ...{ invitations: emptyValues.invitations } }));
-  }, [invitationsInput])
-
+    if (invitationsInput !== "") {
+      setInvitees((prev) => [...prev, invitationsInput]);
+    }
+    setFormData((prev) => ({
+      ...prev,
+      ...{ invitations: emptyValues.invitations },
+    }));
+  }, [invitationsInput]);
 
   useEffect(() => {
-    if(invitees.length !== 0){
+    if (invitees.length !== 0) {
     }
-
-  },[invitees])
+  }, [invitees]);
 
   const changeName = (e) => {
     e.preventDefault();
@@ -102,18 +105,21 @@ export default function NewCapabilityDialog({
 
   const handleAddCapabilityClicked = () => {
     if (onAddCapabilityClicked) {
-      onAddCapabilityClicked({...formData, invitations: invitees});
+      onAddCapabilityClicked({ ...formData, invitations: invitees });
     }
   };
 
   const OnKeyEnter = (e) => {
-    if (e.key === 'Enter'){
+    if (e.key === "Enter") {
       if (!Array.isArray(formData.invitations)) {
-        setInvitees((prev) => ( [...prev, formData.invitations]));
-        setFormData((prev) => ({ ...prev, ...{ invitations: emptyValues.invitations } }));
-      }      
+        setInvitees((prev) => [...prev, formData.invitations]);
+        setFormData((prev) => ({
+          ...prev,
+          ...{ invitations: emptyValues.invitations },
+        }));
+      }
     }
-  }
+  };
 
   return (
     <>
@@ -157,22 +163,28 @@ export default function NewCapabilityDialog({
             placeholder="Enter users emails"
             required
             value={formData.invitations}
-            onChange={(e)=>{changeInvitation(e)}}
+            onChange={(e) => {
+              changeInvitation(e);
+            }}
             onKeyDown={OnKeyEnter}
           ></TextField>
-          { isUserSearchActive ? 
+          {isUserSearchActive ? (
             <div className={styles.dropDownMenu}>
-              <DropDownMenu items={adUsers}
+              <DropDownMenu
+                items={adUsers}
                 setIsUserSearchActive={setIsUserSearchActive}
                 setInvitationsInput={setInvitationsInput}
-                />
-            </div> : <></>}
+              />
+            </div>
+          ) : (
+            <></>
+          )}
           <div className={styles.invitees_container}>
-          {
-              (invitees || []).map((invitee) => (
-                <div className={styles.invitee_container}key={invitee}>{invitee}</div>
-              )) 
-          }
+            {(invitees || []).map((invitee) => (
+              <div className={styles.invitee_container} key={invitee}>
+                {invitee}
+              </div>
+            ))}
           </div>
 
           <ButtonStack>

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -21,7 +21,7 @@ export default function NewCapabilityDialog({
   const emptyValues = {
     name: "",
     description: "",
-    invitations: "",
+    invitations: [],
   };
 
   const [formData, setFormData] = useState(emptyValues);
@@ -42,8 +42,8 @@ export default function NewCapabilityDialog({
 
   const changeInvitation = (e) => {
     e.preventDefault();
-    const newValue = e?.target?.value || emptyValues.invitations;
-    setFormData((prev) => ({ ...prev, ...{ invitations: [newValue] } }));
+    const newValue = e?.target?.value.split(/,\s*/) || emptyValues.invitations;
+    setFormData((prev) => ({ ...prev, ...{ invitations: newValue } }));
   }
 
   const isNameValid =

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -37,19 +37,17 @@ export default function NewCapabilityDialog({
   const [adUsers, setadUsers] = useState([]);
   const [invitationsInput, setInvitationsInput] = useState("")
   const [invitees, setInvitees] = useState([]);
-  const [isInviteesLoaded, setIsInviteesLoaded] = useState(false)
 
   useEffect(() => {
-    console.log(invitationsInput);
     if (invitationsInput !== ""){
       setInvitees((prev) => ( [...prev, invitationsInput]));
     } 
+    setFormData((prev) => ({ ...prev, ...{ invitations: emptyValues.invitations } }));
   }, [invitationsInput])
 
 
   useEffect(() => {
     if(invitees.length !== 0){
-      console.log(invitees)
     }
 
   },[invitees])
@@ -72,7 +70,7 @@ export default function NewCapabilityDialog({
     e.preventDefault();
     const regex = /[^,]*$/;
     setIsUserSearchActive(true);
-    const adValue = e?.target?.value.match(regex)[0].replace(/\s/g, '');
+    const adValue = e?.target?.value.match(regex)[0];
     const value = e?.target?.value;
     const newValue = value || emptyValues.invitations;
     setFormData((prev) => ({ ...prev, ...{ invitations: newValue } }));
@@ -129,9 +127,18 @@ export default function NewCapabilityDialog({
 
   const handleAddCapabilityClicked = () => {
     if (onAddCapabilityClicked) {
-      onAddCapabilityClicked(formData);
+      onAddCapabilityClicked({...formData, invitations: invitees});
     }
   };
+
+  const OnKeyEnter = (e) => {
+    if (e.key === 'Enter'){
+      if (!Array.isArray(formData.invitations)) {
+        setInvitees((prev) => ( [...prev, formData.invitations]));
+        setFormData((prev) => ({ ...prev, ...{ invitations: emptyValues.invitations } }));
+      }      
+    }
+  }
 
   return (
     <>
@@ -176,6 +183,7 @@ export default function NewCapabilityDialog({
             required
             value={formData.invitations}
             onChange={(e)=>{changeInvitation(e)}}
+            onKeyDown={OnKeyEnter}
           ></TextField>
           { isUserSearchActive ? 
             <div className={styles.dropDownMenu}>
@@ -184,12 +192,13 @@ export default function NewCapabilityDialog({
                 setInvitationsInput={setInvitationsInput}
                 />
             </div> : <></>}
-
+          <div className={styles.invitees_container}>
           {
               (invitees || []).map((invitee) => (
-                <div key={invitee}>{invitee}</div>
+                <div className={styles.invitee_container}key={invitee}>{invitee}</div>
               )) 
           }
+          </div>
 
           <ButtonStack>
             <Button

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -4,15 +4,7 @@ import { SideSheet, SideSheetContent } from "@dfds-ui/react-components";
 import { Tooltip, TextField } from "@dfds-ui/react-components";
 import styles from "./capabilities.module.css";
 import { getUsers } from "GraphApiClient";
-import DropDownMenu from "components/DropDownMenu";
-
-function TextWrapper() {
-  return (
-    <>
-      <div className=""></div>
-    </>
-  );
-}
+import DropDownInvitationsMenu from "components/DropDownMenu";
 
 export default function NewCapabilityDialog({
   inProgress,
@@ -71,13 +63,13 @@ export default function NewCapabilityDialog({
 
   async function changeInvitation(e) {
     e.preventDefault();
-    const regex = /[^,]*$/;
+    const regex = /[^,]*$/; //takes all invitees separate them by comma and add them to an array
     setIsUserSearchActive(true);
-    const adValue = e?.target?.value.match(regex)[0];
+    const adUsers = e?.target?.value.match(regex)[0];
     const value = e?.target?.value;
     const newValue = value || emptyValues.invitations;
     setFormData((prev) => ({ ...prev, ...{ invitations: newValue } }));
-    const adUserstest = await getUsers(adValue);
+    const adUserstest = await getUsers(adUsers);
     setadUsers(adUserstest.value);
   }
 
@@ -111,7 +103,9 @@ export default function NewCapabilityDialog({
 
   const OnKeyEnter = (e) => {
     if (e.key === "Enter") {
-      if (!Array.isArray(formData.invitations)) {
+      if (Array.isArray(formData.invitations)) {
+        return;        
+      } else {
         setInvitees((prev) => [...prev, formData.invitations]);
         setFormData((prev) => ({
           ...prev,
@@ -170,7 +164,7 @@ export default function NewCapabilityDialog({
           ></TextField>
           {isUserSearchActive ? (
             <div className={styles.dropDownMenu}>
-              <DropDownMenu
+              <DropDownInvitationsMenu
                 items={adUsers}
                 setIsUserSearchActive={setIsUserSearchActive}
                 setInvitationsInput={setInvitationsInput}

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -104,7 +104,7 @@ export default function NewCapabilityDialog({
   const OnKeyEnter = (e) => {
     if (e.key === "Enter") {
       if (Array.isArray(formData.invitations)) {
-        return;        
+        return;
       } else {
         setInvitees((prev) => [...prev, formData.invitations]);
         setFormData((prev) => ({

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -21,6 +21,7 @@ export default function NewCapabilityDialog({
   const emptyValues = {
     name: "",
     description: "",
+    invitations: "",
   };
 
   const [formData, setFormData] = useState(emptyValues);
@@ -38,6 +39,12 @@ export default function NewCapabilityDialog({
     const newValue = e?.target?.value || emptyValues.description;
     setFormData((prev) => ({ ...prev, ...{ description: newValue } }));
   };
+
+  const changeInvitation = (e) => {
+    e.preventDefault();
+    const newValue = e?.target?.value || emptyValues.invitations;
+    setFormData((prev) => ({ ...prev, ...{ invitations: [newValue] } }));
+  }
 
   const isNameValid =
     formData.name !== "" &&
@@ -102,6 +109,14 @@ export default function NewCapabilityDialog({
             required
             value={formData.description}
             onChange={changeDescription}
+          ></TextField>
+
+          <TextField
+            label="Invite members"
+            placeholder="Enter users emails"
+            required
+            value={formData.invitations}
+            onChange={changeInvitation}
           ></TextField>
 
           <ButtonStack>

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -1,8 +1,16 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button, ButtonStack } from "@dfds-ui/react-components";
 import { SideSheet, SideSheetContent } from "@dfds-ui/react-components";
 import { Tooltip, TextField } from "@dfds-ui/react-components";
 import styles from "./capabilities.module.css";
+import { getUsers } from "GraphApiClient";
+import DropDownMenu from "components/DropDownMenu";
+
+function TextWrapper(){
+  return <>
+  <div className=""></div>
+  </>
+}
 
 export default function NewCapabilityDialog({
   inProgress,
@@ -25,6 +33,26 @@ export default function NewCapabilityDialog({
   };
 
   const [formData, setFormData] = useState(emptyValues);
+  const [isUserSearchActive, setIsUserSearchActive] = useState(false);
+  const [adUsers, setadUsers] = useState([]);
+  const [invitationsInput, setInvitationsInput] = useState("")
+  const [invitees, setInvitees] = useState([]);
+  const [isInviteesLoaded, setIsInviteesLoaded] = useState(false)
+
+  useEffect(() => {
+    console.log(invitationsInput);
+    if (invitationsInput !== ""){
+      setInvitees((prev) => ( [...prev, invitationsInput]));
+    } 
+  }, [invitationsInput])
+
+
+  useEffect(() => {
+    if(invitees.length !== 0){
+      console.log(invitees)
+    }
+
+  },[invitees])
 
   const changeName = (e) => {
     e.preventDefault();
@@ -40,10 +68,41 @@ export default function NewCapabilityDialog({
     setFormData((prev) => ({ ...prev, ...{ description: newValue } }));
   };
 
-  const changeInvitation = (e) => {
+  async function changeInvitation(e) {
     e.preventDefault();
-    const newValue = e?.target?.value || emptyValues.invitations;
+    const regex = /[^,]*$/;
+    setIsUserSearchActive(true);
+    const adValue = e?.target?.value.match(regex)[0].replace(/\s/g, '');
+    const value = e?.target?.value;
+    const newValue = value || emptyValues.invitations;
     setFormData((prev) => ({ ...prev, ...{ invitations: newValue } }));
+    const adUserstest = await getUsers(adValue);
+    setadUsers(adUserstest.value);
+  }
+
+  function updateInvitees(email) {
+    // const newValue = email || emptyValues.invitations;
+    // console.log(newValue);
+    // console.log(formData);
+    // const regex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+    // console.log(formData.invitations[0]);
+    // const result = formData.invitations[0].split(',').map(part => {
+    //   console.log(part);
+    //   const trimmedPart = part.trim();
+    //   const isValidEmail = regex.test(trimmedPart);
+    //   if (isValidEmail) {
+    //     return trimmedPart
+    //   }
+      
+    // }).filter(email => email);
+
+    // console.log(result);
+    
+    // setFormData((prev) => ({ ...prev, invitations: [result, newValue] }));
+    
+
+
+
   }
 
   const isNameValid =
@@ -116,8 +175,21 @@ export default function NewCapabilityDialog({
             placeholder="Enter users emails"
             required
             value={formData.invitations}
-            onChange={changeInvitation}
+            onChange={(e)=>{changeInvitation(e)}}
           ></TextField>
+          { isUserSearchActive ? 
+            <div className={styles.dropDownMenu}>
+              <DropDownMenu items={adUsers}
+                setIsUserSearchActive={setIsUserSearchActive}
+                setInvitationsInput={setInvitationsInput}
+                />
+            </div> : <></>}
+
+          {
+              (invitees || []).map((invitee) => (
+                <div key={invitee}>{invitee}</div>
+              )) 
+          }
 
           <ButtonStack>
             <Button

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -78,31 +78,6 @@ export default function NewCapabilityDialog({
     setadUsers(adUserstest.value);
   }
 
-  function updateInvitees(email) {
-    // const newValue = email || emptyValues.invitations;
-    // console.log(newValue);
-    // console.log(formData);
-    // const regex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
-    // console.log(formData.invitations[0]);
-    // const result = formData.invitations[0].split(',').map(part => {
-    //   console.log(part);
-    //   const trimmedPart = part.trim();
-    //   const isValidEmail = regex.test(trimmedPart);
-    //   if (isValidEmail) {
-    //     return trimmedPart
-    //   }
-      
-    // }).filter(email => email);
-
-    // console.log(result);
-    
-    // setFormData((prev) => ({ ...prev, invitations: [result, newValue] }));
-    
-
-
-
-  }
-
   const isNameValid =
     formData.name !== "" &&
     !formData.name.match(/^\s*$/g) &&

--- a/src/src/pages/capabilities/capabilities.module.css
+++ b/src/src/pages/capabilities/capabilities.module.css
@@ -44,3 +44,13 @@
 .cardMedia {
   position: unset !important;
 }
+
+.dropDownMenu {
+  position: relative;
+  top: -23px;
+}
+
+.dropDownMenu {
+  position: relative;
+  top: -23px;
+}

--- a/src/src/pages/capabilities/capabilities.module.css
+++ b/src/src/pages/capabilities/capabilities.module.css
@@ -50,7 +50,20 @@
   top: -23px;
 }
 
-.dropDownMenu {
+.invitee_container {
+  display: flex;
+  border: 2px solid #d9dcde;
+  padding: 5px 5px 5px 5px;
+  margin-left: 4px;
+  border-radius: 20px;
+  background-color: #d9dcde;  
+  margin-bottom: 4px;
+}
+
+.invitees_container {
+  display: flex;
+  flex-direction: row;
   position: relative;
-  top: -23px;
+  top: -16px;
+  flex-wrap: wrap;
 }

--- a/src/src/pages/capabilities/capabilities.module.css
+++ b/src/src/pages/capabilities/capabilities.module.css
@@ -56,7 +56,7 @@
   padding: 5px 5px 5px 5px;
   margin-left: 4px;
   border-radius: 20px;
-  background-color: #d9dcde;  
+  background-color: #d9dcde;
   margin-bottom: 4px;
 }
 

--- a/src/src/pages/capabilities/index.js
+++ b/src/src/pages/capabilities/index.js
@@ -24,7 +24,11 @@ export default function CapabilitiesPage() {
 
   const handleAddCapability = async (formData) => {
     setIsCreatingNewCapability(true);
-    await addNewCapability(formData.name, formData.description, formData.invitations);
+    await addNewCapability(
+      formData.name,
+      formData.description,
+      formData.invitations,
+    );
     setShowNewCapabilityDialog(false);
     setIsCreatingNewCapability(false);
   };

--- a/src/src/pages/capabilities/index.js
+++ b/src/src/pages/capabilities/index.js
@@ -23,7 +23,7 @@ export default function CapabilitiesPage() {
 
   const handleAddCapability = async (formData) => {
     setIsCreatingNewCapability(true);
-    await addNewCapability(formData.name, formData.description);
+    await addNewCapability(formData.name, formData.description, formData.invitations);
     setShowNewCapabilityDialog(false);
     setIsCreatingNewCapability(false);
   };

--- a/src/src/pages/capabilities/invitations/index.js
+++ b/src/src/pages/capabilities/invitations/index.js
@@ -1,0 +1,10 @@
+import PageSection from "components/PageSection";
+import { useState, useContext, useEffect, useCallback } from "react";
+
+export function Invitations() {
+  return (
+    <>
+      <PageSection headline="Invitations"></PageSection>
+    </>
+  );
+}


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2229

# Additional Review Notes
You invite AD users to on creation of a capability. 

![image](https://github.com/dfds/selfservice-portal/assets/58768740/afe808f0-e60c-4881-8022-a1db1713b557)

The already picked users are stored below the invitees input text: 

![image](https://github.com/dfds/selfservice-portal/assets/58768740/768341bf-0fcf-44c8-bc74-f7b40dfd01e3)


**Note: This is not perfect it is an initial state there is a lot room for improvements** 



