### PR TITLE
Sticky Toasts. Om nom nom

### DIFF
--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -6,7 +6,7 @@
   margin: 5px;
   opacity: 0;
   transition: 300ms all ease;
-  height: 120px;
+  transform: translateX(-50%);
 }
 .hidden {
   height: 0;

--- a/src/src/errordisplay.module.css
+++ b/src/src/errordisplay.module.css
@@ -1,6 +1,6 @@
 .toasts_container {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  position: sticky;
   bottom: 1rem;
+  width: 100%;
+  margin-left: 50%;
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2232

# Additional Review Notes
Also let the toasts figure out their own size, as the details button was not properly contained with the 120px

![image](https://github.com/dfds/selfservice-portal/assets/177252/cc13ff64-7043-4f8e-99f4-f922eef14a63)


It's hard to make image of the sticky-ness