### PR TITLE
Feature/2261 bug error details box not showing details from selfservice api

### DIFF
--- a/src/src/ErrorContext.js
+++ b/src/src/ErrorContext.js
@@ -16,7 +16,7 @@ function ErrorProvider({ children }) {
   const [errors, setErrors] = useState([]);
 
   const showError = (errorTitle, errorDetails) => {
-    console.log(`adding new error: ${errorTitle} ${errorDetails}`); //leaving this here for debugging inb4 comment on PR
+    console.log(`adding new error: ${errorTitle} ${errorDetails}`); // left here for debugging purposes
     const error = new ErrorContent(errorTitle, errorDetails);
     setErrors((prevError) => [...prevError, error]);
   };

--- a/src/src/ErrorContext.js
+++ b/src/src/ErrorContext.js
@@ -2,10 +2,10 @@ import ErrorDisplay from "ErrorDisplay";
 import React, { createContext, useEffect, useState } from "react";
 
 class ErrorContent {
-  msg = null;
+  title = null;
   details = null;
-  constructor(msg, details) {
-    this.msg = msg;
+  constructor(title, details) {
+    this.title = title;
     this.details = details;
   }
 }
@@ -15,9 +15,9 @@ const ErrorContext = createContext();
 function ErrorProvider({ children }) {
   const [errors, setErrors] = useState([]);
 
-  const showError = (errorMessage, errorDetails = null) => {
-    // console.log("adding new error with msg: ", errorMessage); //leaving this here for debugging inb4 comment on PR
-    const error = new ErrorContent(errorMessage, errorDetails);
+  const showError = (errorTitle, errorDetails) => {
+    console.log(`adding new error: ${errorTitle} ${errorDetails}`); //leaving this here for debugging inb4 comment on PR
+    const error = new ErrorContent(errorTitle, errorDetails);
     setErrors((prevError) => [...prevError, error]);
   };
 

--- a/src/src/ErrorDisplay.js
+++ b/src/src/ErrorDisplay.js
@@ -5,7 +5,7 @@ import styles from "errordisplay.module.css";
 
 const ErrorDisplay = () => {
   const defaultErrorMessage =
-    "Oh no! We had an issue while loading the page, you can try reloading to see if it fixes it.";
+    "Oh no! Something went wrong while loading the page. You can try refreshing to resolve the issue.";
   const { errors } = useContext(ErrorContext); //error is multiple errors
   if (errors.length === 0) {
     return null;

--- a/src/src/ErrorDisplay.js
+++ b/src/src/ErrorDisplay.js
@@ -17,8 +17,8 @@ const ErrorDisplay = () => {
           <ErrorToast
             key={index}
             message={defaultErrorMessage}
-            errorTitle={e.title}
-            errorDetails={e.details}
+            title={e.title}
+            details={e.details}
           ></ErrorToast>
         </>
       ))}

--- a/src/src/ErrorDisplay.js
+++ b/src/src/ErrorDisplay.js
@@ -1,9 +1,11 @@
 import React, { useContext } from "react";
 import ErrorContext from "./ErrorContext";
-import Toast from "components/Toast/index.js";
+import ErrorToast from "components/Toast/index.js";
 import styles from "errordisplay.module.css";
 
 const ErrorDisplay = () => {
+  const defaultErrorMessage =
+    "Oh no! We had an issue while loading the page, you can try reloading to see if it fixes it.";
   const { errors } = useContext(ErrorContext); //error is multiple errors
   if (errors.length === 0) {
     return null;
@@ -12,11 +14,12 @@ const ErrorDisplay = () => {
     <div className={styles.toasts_container}>
       {errors.map((e, index) => (
         <>
-          <Toast
+          <ErrorToast
             key={index}
-            message={e.msg}
-            details={e.details ? e.details : null}
-          ></Toast>
+            message={defaultErrorMessage}
+            errorTitle={e.title}
+            errorDetails={e.details}
+          ></ErrorToast>
         </>
       ))}
     </div>

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -69,9 +69,19 @@ export default function ErrorToast({ message, errorTitle, errorDetails }) {
           fixedTopPosition={true}
           onRequestClose={() => setShowDetails(false)}
           actions={actions}
-          className={styles.modal}
+          sizes={{
+            s: "50%",
+            m: "50%",
+            l: "50%",
+            xl: "50%",
+            xxl: "50%",
+          }}
         >
-          {errorDetails ? <div>{errorDetails}</div> : "No details available"}
+          {errorDetails ? (
+            <div className={styles.error_body}>{errorDetails}</div>
+          ) : (
+            "No details available"
+          )}
         </Modal>
       )}
       {showToast && (

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -15,7 +15,7 @@ function usePrevious(value) {
   return ref.current;
 }
 
-export default function Toast({ message, details }) {
+export default function ErrorToast({ message, errorTitle, errorDetails }) {
   const [showToast, setShowToast] = useState(true);
   const [showDetails, setShowDetails] = useState(false);
   const [opacity, setOpacity] = useState(0);
@@ -59,29 +59,16 @@ export default function Toast({ message, details }) {
 
   return (
     <>
-      {showDetails && details && (
+      {showDetails && errorDetails && (
         <Modal
-          heading={`Details`}
+          heading={errorTitle}
           isOpen={true}
           shouldCloseOnOverlayClick={true}
           shouldCloseOnEsc={true}
           onRequestClose={() => setShowDetails(false)}
           actions={actions}
         >
-          {console.log("details in component: ", details)}
-          {details ? (
-            <div>
-              {"Got " +
-                details.status +
-                ': "' +
-                details.statusText +
-                '" for ' +
-                details.url +
-                "."}
-            </div>
-          ) : (
-            "No details available"
-          )}
+          {errorDetails ? <div>{errorDetails}</div> : "No details available"}
         </Modal>
       )}
       {showToast && (
@@ -100,7 +87,7 @@ export default function Toast({ message, details }) {
             </Button>
           </div>
           <div className={styles.toast_message}>{message}</div>
-          {details && (
+          {errorDetails && (
             <div>
               <Button
                 size="small"

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -15,7 +15,7 @@ function usePrevious(value) {
   return ref.current;
 }
 
-export default function ErrorToast({ message, errorTitle, errorDetails }) {
+export default function ErrorToast({ message, title, details }) {
   const [showToast, setShowToast] = useState(true);
   const [showDetails, setShowDetails] = useState(false);
   const [opacity, setOpacity] = useState(0);
@@ -59,9 +59,9 @@ export default function ErrorToast({ message, errorTitle, errorDetails }) {
 
   return (
     <>
-      {showDetails && errorDetails && (
+      {showDetails && details && (
         <Modal
-          heading={errorTitle}
+          heading={title}
           isOpen={true}
           shouldCloseOnOverlayClick={true}
           shouldCloseOnEsc={true}
@@ -77,8 +77,8 @@ export default function ErrorToast({ message, errorTitle, errorDetails }) {
             xxl: "50%",
           }}
         >
-          {errorDetails ? (
-            <div className={styles.error_body}>{errorDetails}</div>
+          {details ? (
+            <div className={styles.error_body}>{details}</div>
           ) : (
             "No details available"
           )}
@@ -100,7 +100,7 @@ export default function ErrorToast({ message, errorTitle, errorDetails }) {
             </Button>
           </div>
           <div className={styles.toast_message}>{message}</div>
-          {errorDetails && (
+          {details && (
             <div>
               <Button
                 size="small"

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -81,7 +81,6 @@ export default function ErrorToast({ message, errorTitle, errorDetails }) {
               size="small"
               variation="link"
               fillWidth="true"
-              className={styles.toast_close_bar_button}
               onClick={() => setOpacity(0)}
             >
               <Close className={styles.close_icon} />

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -65,8 +65,11 @@ export default function ErrorToast({ message, errorTitle, errorDetails }) {
           isOpen={true}
           shouldCloseOnOverlayClick={true}
           shouldCloseOnEsc={true}
+          showClose={false}
+          fixedTopPosition={true}
           onRequestClose={() => setShowDetails(false)}
           actions={actions}
+          className={styles.modal}
         >
           {errorDetails ? <div>{errorDetails}</div> : "No details available"}
         </Modal>

--- a/src/src/components/Toast/index.js
+++ b/src/src/components/Toast/index.js
@@ -81,6 +81,7 @@ export default function ErrorToast({ message, errorTitle, errorDetails }) {
               size="small"
               variation="link"
               fillWidth="true"
+              className={styles.toast_close_bar_button}
               onClick={() => setOpacity(0)}
             >
               <Close className={styles.close_icon} />

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -19,8 +19,9 @@
   justify-content: center;
 }
 
-.modal{
+.error_body {
   white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 .toast_close_bar {

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -44,7 +44,7 @@
   bottom: 0.7rem;
   transform: translateX(-50%);
   font-size: 0.8rem;
-  color: #6d6d6d;
+  color: #bbbbbb;
   cursor: pointer;
 }
 

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -1,7 +1,7 @@
 .toast_container {
   position: relative;
   background-color: rgba(190, 30, 45);
-  width: 284px;
+  width: 290px;
   border-radius: 5px;
   margin: 5px;
   opacity: 0;
@@ -25,7 +25,7 @@
   text-align: right;
 }
 
-.toast_close_bar_button {
+.toast_close_bar button {
   width: 32px;
 }
 

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -8,6 +8,7 @@
   transition: 300ms all ease;
   transform: translateX(-50%);
 }
+
 .hidden {
   height: 0;
   padding: 0;
@@ -15,18 +16,19 @@
 }
 
 .container_toast_message {
-  display: flex;
   justify-content: center;
 }
 
 .toast_close_bar {
   width: 100%;
+  height: 32px;
   text-align: right;
-  padding-right: 0.5rem;
 }
-.toast_close_bar button {
-  width: 20px;
+
+.toast_close_bar_button {
+  width: 32px;
 }
+
 .close_icon {
   font-size: 20px;
   font-weight: bold;
@@ -36,13 +38,11 @@
 .toast_message {
   color: #ffffff;
   text-align: center;
-  padding: 0.5rem;
+  padding: 0 20px;
 }
 
 .toast_details_button {
   position: relative;
-  bottom: 0.7rem;
-  transform: translateX(-50%);
   font-size: 0.8rem;
   color: #bbbbbb;
   cursor: pointer;

--- a/src/src/components/Toast/toast.module.css
+++ b/src/src/components/Toast/toast.module.css
@@ -19,6 +19,10 @@
   justify-content: center;
 }
 
+.modal{
+  white-space: pre-wrap;
+}
+
 .toast_close_bar {
   width: 100%;
   height: 32px;

--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -64,26 +64,7 @@ export function useCapabilityById(id) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [capability, setCapability] = useState(null);
   const { inProgress, responseData, setErrorOptions, sendRequest } =
-    useSelfServiceRequest({
-      handler: (params) => {
-        if (params.error) {
-          params.showError(params.error.message);
-          return;
-        }
-
-        if (params.httpResponse) {
-          if (params.httpResponse.status === 404) {
-            params.showError("Capability not found");
-            return;
-          }
-
-          params.showError(params.httpResponse.statusText);
-          return;
-        }
-
-        params.showError(params.msg);
-      },
-    });
+    useSelfServiceRequest();
 
   useEffect(() => {
     if (id != null) {

--- a/src/src/hooks/Error.js
+++ b/src/src/hooks/Error.js
@@ -12,18 +12,18 @@ export function useError(opts) {
   ///   1: Handler provided via params
   ///   2: Handler provided via options
   ///   3: Error provided via params
-  ///   4: Msg provided via params
-  ///   5: fallbackMsg
+  ///   4: title provided via params
+  ///   5: fallbacktitle
   ///
   const triggerError = (params) => {
     // Setup
-    let fallbackMsg = "error";
+    let fallbackTitle = "error";
     if (params) {
       params.showError = showError;
     }
 
-    if (options?.msg != null) {
-      fallbackMsg = options.msg; // If a catch-all error message is available in options, make sure it is used as a fallback
+    if (options?.title != null) {
+      fallbackTitle = options.title; // If a catch-all error message is available in options, make sure it is used as a fallback
     }
 
     // Error handling flow
@@ -35,8 +35,8 @@ export function useError(opts) {
 
     if (options?.handler != null) {
       // 2: Handler provided via options
-      if (params.msg === null) {
-        params.msg = fallbackMsg;
+      if (params.title === null) {
+        params.title = fallbackTitle;
       }
       options.handler(params);
       return;
@@ -49,19 +49,24 @@ export function useError(opts) {
         return;
       }
 
-      if (params.msg) {
-        // 4: Msg provided via params
-        showError(params.msg, params.details);
+      if (params.title) {
+        // 4: title provided via params
+        showError(params.title, params.details);
         return;
       }
     }
 
-    showError(fallbackMsg, params.httpResponse); // 5: fallbackMsg
+    showError(fallbackTitle, params.httpResponse); // 5: fallbacktitle
+  };
+
+  const triggerErrorWithTitleAndDetails = (errorTitle, errorDetails) => {
+    showError(errorTitle, errorDetails);
   };
 
   return {
     options,
     setErrorOptions: setOptions,
+    triggerErrorWithTitleAndDetails,
     triggerError,
   };
 }

--- a/src/src/hooks/Error.js
+++ b/src/src/hooks/Error.js
@@ -5,60 +5,6 @@ export function useError(opts) {
   const [options, setOptions] = useState(opts);
   const { showError } = useContext(ErrorContext);
 
-  ///
-  /// triggerError
-  ///
-  /// Priority of error handling flow
-  ///   1: Handler provided via params
-  ///   2: Handler provided via options
-  ///   3: Error provided via params
-  ///   4: title provided via params
-  ///   5: fallbacktitle
-  ///
-  const triggerError = (params) => {
-    // Setup
-    let fallbackTitle = "error";
-    if (params) {
-      params.showError = showError;
-    }
-
-    if (options?.title != null) {
-      fallbackTitle = options.title; // If a catch-all error message is available in options, make sure it is used as a fallback
-    }
-
-    // Error handling flow
-    if (params?.handler != null) {
-      // 1: Handler provided via params
-      params.handler(params);
-      return;
-    }
-
-    if (options?.handler != null) {
-      // 2: Handler provided via options
-      if (params.title === null) {
-        params.title = fallbackTitle;
-      }
-      options.handler(params);
-      return;
-    }
-
-    if (params) {
-      if (params.error) {
-        // 3: Error provided via params
-        showError(params.error.message, params.details);
-        return;
-      }
-
-      if (params.title) {
-        // 4: title provided via params
-        showError(params.title, params.details);
-        return;
-      }
-    }
-
-    showError(fallbackTitle, params.httpResponse); // 5: fallbacktitle
-  };
-
   const triggerErrorWithTitleAndDetails = (errorTitle, errorDetails) => {
     showError(errorTitle, errorDetails);
   };
@@ -67,6 +13,5 @@ export function useError(opts) {
     options,
     setErrorOptions: setOptions,
     triggerErrorWithTitleAndDetails,
-    triggerError,
   };
 }

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -12,10 +12,9 @@ function isValidURL(urlString) {
 export function useSelfServiceRequest(errorParams) {
   const [responseData, setResponseData] = useState(null);
   const [inProgress, setInProgress] = useState(false);
-  const { triggerError, triggerErrorWithTitleAndDetails, setErrorOptions } =
-    useError({
-      ...errorParams,
-    });
+  const { triggerErrorWithTitleAndDetails, setErrorOptions } = useError({
+    ...errorParams,
+  });
   const { track } = useTracking();
 
   const httpResponseToErrorMessage = (httpResponse) => {
@@ -66,7 +65,6 @@ export function useSelfServiceRequest(errorParams) {
   return {
     inProgress,
     responseData,
-    triggerError,
     triggerErrorWithTitleAndDetails,
     setErrorOptions,
     sendRequest,

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -55,7 +55,8 @@ export function useSelfServiceRequest(errorParams) {
         }
       }
     } catch (error) {
-      const errorDetails = `Error when calling ${method} ${url}:\n${error}`;
+      const actualMethod = method || "GET";
+      const errorDetails = `Error when calling ${actualMethod} ${url}:\n${error}`;
       triggerErrorWithTitleAndDetails("Http Error", errorDetails);
     } finally {
       setInProgress(false);

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -19,7 +19,7 @@ export function useSelfServiceRequest(errorParams) {
   const { track } = useTracking();
 
   const httpResponseToErrorMessage = (httpResponse) => {
-    return `Got ${httpResponse.status}: "${httpResponse.title}" for ${httpResponse.url}`;
+    return `Got ${httpResponse.status}: "${httpResponse.statusText}" for ${httpResponse.url}`;
   };
 
   const sendRequest = async ({ urlSegments, method, payload }) => {

--- a/src/src/hooks/SelfServiceApi.js
+++ b/src/src/hooks/SelfServiceApi.js
@@ -45,7 +45,7 @@ export function useSelfServiceRequest(errorParams) {
         const errorDetails = newData.detail;
         const httpError = httpResponseToErrorMessage(httpResponse);
         if (errorDetails && errorTitle) {
-          const problemDetailsWithHttpError = `${errorDetails}\n${httpError}`;
+          const problemDetailsWithHttpError = errorDetails + "\n\n" + httpError;
           triggerErrorWithTitleAndDetails(
             errorTitle,
             problemDetailsWithHttpError,

--- a/src/src/hooks/Topics.js
+++ b/src/src/hooks/Topics.js
@@ -41,10 +41,10 @@ export function useDeleteTopic() {
     useSelfServiceRequest();
   const deleteTopic = (topicDefinition) => {
     const link = topicDefinition?._links?.self;
-    if (!link) {
+    if (link) {
       triggerErrorWithTitleAndDetails(
-        "Error",
-        "No topic self link found on topic definition: " +
+        "Delete topic failed",
+        "No topic self link found on topic definition:\n" +
           JSON.stringify(topicDefinition, null, 2),
       );
       return;
@@ -52,8 +52,8 @@ export function useDeleteTopic() {
 
     if (!(link.allow || []).includes("DELETE")) {
       triggerErrorWithTitleAndDetails(
-        "Error",
-        "You are not allowed to delete the topic. Options was " +
+        "Delete topic failed",
+        "You are not allowed to delete the topic. Options are\n" +
           JSON.stringify(link.allow, null, 2),
       );
       return;
@@ -75,7 +75,7 @@ export function useUpdateTopic() {
     const link = topicDefinition?._links?.updateDescription;
     if (!link) {
       triggerErrorWithTitleAndDetails(
-        "Error",
+        "Update topic failed",
         "No update topic description link found on topic definition: " +
           JSON.stringify(topicDefinition, null, 2),
       );

--- a/src/src/hooks/Topics.js
+++ b/src/src/hooks/Topics.js
@@ -37,29 +37,24 @@ export function useTopics() {
 }
 
 export function useDeleteTopic() {
-  const { triggerError, sendRequest } = useSelfServiceRequest();
+  const { triggerErrorWithTitleAndDetails, sendRequest } =
+    useSelfServiceRequest();
   const deleteTopic = (topicDefinition) => {
     const link = topicDefinition?._links?.self;
     if (!link) {
-      triggerError(
-        NewErrorContextBuilder()
-          .setMsg(
-            "Error! No topic self link found on topic definition: " +
-              JSON.stringify(topicDefinition, null, 2),
-          )
-          .build(),
+      triggerErrorWithTitleAndDetails(
+        "Error",
+        "No topic self link found on topic definition: " +
+          JSON.stringify(topicDefinition, null, 2),
       );
       return;
     }
 
     if (!(link.allow || []).includes("DELETE")) {
-      triggerError(
-        NewErrorContextBuilder()
-          .setMsg(
-            "Error! You are not allowed to delete the topic. Options was " +
-              JSON.stringify(link.allow, null, 2),
-          )
-          .build(),
+      triggerErrorWithTitleAndDetails(
+        "Error",
+        "You are not allowed to delete the topic. Options was " +
+          JSON.stringify(link.allow, null, 2),
       );
       return;
     }
@@ -74,15 +69,15 @@ export function useDeleteTopic() {
 }
 
 export function useUpdateTopic() {
-  const { triggerError, sendRequest } = useSelfServiceRequest();
+  const { triggerErrorWithTitleAndDetails, sendRequest } =
+    useSelfServiceRequest();
   return (topicDefinition, topicDescriptor) => {
     const link = topicDefinition?._links?.updateDescription;
     if (!link) {
-      triggerError(
-        NewErrorContextBuilder().setMsg(
-          "Error! No update topic description link found on topic definition: " +
-            JSON.stringify(topicDefinition, null, 2),
-        ),
+      triggerErrorWithTitleAndDetails(
+        "Error",
+        "No update topic description link found on topic definition: " +
+          JSON.stringify(topicDefinition, null, 2),
       );
     }
 


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2261

# Additional Review Notes

## Tweaking
- Made error showing consistent always need title and description
- Made "Oh no!" text always shown and rewrote message
- Did some tweaks to styling of the error toasts:
- Made details button easy to see
- Made space between details button and body text bigger
- Fixed weird logic for putting x button in the corner
- Error details modal now respects newlines

## Screen shots
Http error:
<img width="515" alt="image" src="https://github.com/dfds/selfservice-portal/assets/5738476/cb580c1f-d45b-4c02-bc19-b7e2440c7e68">

Problem details error:
<img width="579" alt="image" src="https://github.com/dfds/selfservice-portal/assets/5738476/539c64e8-e6d3-4828-ac01-1906af76244d">

Custom errors:
<img width="729" alt="image" src="https://github.com/dfds/selfservice-portal/assets/5738476/61f5873d-c390-480c-b98b-32a3d0c156eb">
