### PR TITLE
Add vscode project configs for formatting using prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/setup-pre-commit-hook.sh
+++ b/setup-pre-commit-hook.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-echo "Installing prettier"
-npm install --save-dev --save-exact prettier
+./setup-tooling.sh
 
 echo "Creating pre-commit hook"
 mkdir .git/hooks 2>&-

--- a/setup-tooling.sh
+++ b/setup-tooling.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Installing prettier"
+npm install --save-dev --save-exact prettier


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2275

Would appreciate a hand testing if this works (if you are using vscode for this project)

With the changes made in this PR, vscode should sent you a notification when you open the project, asking you to install the prettier extension if it is not already installed.

It'll also override 2 of your global vscode settings for this project only:
- On file save it will automatically format your file
- It'll change the default formatter for all files in the project to prettier

If you don't already have prettier installed via npm, you can either run the setup-tooling.sh script in the root of the project directory or simple run `npm install --save-dev --save-exact prettier` while being inside the root of the project directory.