### PR TITLE
Re-enable finout link on Capablity page

### DIFF
--- a/src/src/pages/capabilities/costs/index.js
+++ b/src/src/pages/capabilities/costs/index.js
@@ -51,9 +51,12 @@ export default function Costs() {
                         data={dataValue}
                         capabilityId={id}
                       />
-                      <Text className={styles.finout_link}>
-                        <ins>Finout link coming soon</ins>
-                      </Text>
+                      <a
+                        target="_blank"
+                        href={`https://app.finout.io/app/total-cost?accountId=e071c3ed-1e3c-46f7-9830-71951712d791&context=%7B%22id%22%3A%2288dc362c-5876-45d9-8c9e-950f1f481e78%22%2C%22metricName%22%3A%22MegaBill%22%2C%22type%22%3A%22cost%22%2C%22name%22%3A%22MegaBill%22%2C%22label%22%3A%22unlabeled%22%2C%22tags%22%3A%7B%7D%2C%22costViewId%22%3A%2232%22%2C%22unitAggregationCount%22%3A1%7D&gbyHiddenLegendIndexes=0_2&filters=%7B%22costCenter%22%3A%22virtualTag%22%2C%22key%22%3A%2252c02d7e-093a-42b7-bf06-eb13050a8687%22%2C%22path%22%3A%22Virtual+Tags%F0%9F%94%A5%2Fcapability%22%2C%22type%22%3A%22virtual_tag%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%22${id}%22%${days}D`}
+                      >
+                        Finout link
+                      </a>
                     </>
                   )}
                 </>


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2296

See issue for no additional context: https://github.com/dfds/cloudplatform/issues/2296

Before:
![Screenshot 2023-11-20 at 1  44 16@2x](https://github.com/dfds/selfservice-portal/assets/1633308/803b29b9-3ffe-46d3-b2bc-3aef3959e59f)

After:
![Screenshot 2023-11-20 at 1  44 31@2x](https://github.com/dfds/selfservice-portal/assets/1633308/e7608e8a-1eff-4feb-bde3-09f2dc14e320)
