### PR TITLE
Added css overflow to the appropriate elements, so the cost tooltip is not cut off

### DIFF
--- a/src/src/pages/capabilities/MyCapabilities.js
+++ b/src/src/pages/capabilities/MyCapabilities.js
@@ -202,6 +202,11 @@ export default function MyCapabilities() {
                 pagination: { pageSize: 25 },
                 showGlobalFilter: true,
               }}
+              muiTableContainerProps={{
+                sx: {
+                  overflow: "visible",
+                },
+              }}
               muiTableHeadCellProps={{
                 sx: {
                   fontWeight: "700",
@@ -217,6 +222,7 @@ export default function MyCapabilities() {
                   fontFamily: "DFDS",
                   color: "#4d4e4c",
                   padding: "5px",
+                  overflow: "visible",
                 },
               }}
               muiTablePaperProps={{


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2058

Before:
![Screenshot 2023-11-21 at 11  25 19@2x](https://github.com/dfds/selfservice-portal/assets/1633308/8059e3ee-1394-45a8-a4b6-8be1178fc2c6)
![Screenshot 2023-11-21 at 11  25 31@2x](https://github.com/dfds/selfservice-portal/assets/1633308/149b911a-37aa-42a7-a509-c3d77910d88a)

After:
![Screenshot 2023-11-21 at 11  27 35@2x](https://github.com/dfds/selfservice-portal/assets/1633308/257178ce-bcc5-4cab-ab86-c7f1f557b065)
