### PR TITLE
Fixed unable to delete topics

### DIFF
--- a/src/src/hooks/Topics.js
+++ b/src/src/hooks/Topics.js
@@ -41,7 +41,7 @@ export function useDeleteTopic() {
     useSelfServiceRequest();
   const deleteTopic = (topicDefinition) => {
     const link = topicDefinition?._links?.self;
-    if (link) {
+    if (!link) {
       triggerErrorWithTitleAndDetails(
         "Delete topic failed",
         "No topic self link found on topic definition:\n" +


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2303

# Additional Review Notes
I believe that this issue was broken when deleting topics got converted into a hook and I think we were not aware of the issue because the error message box didnt pop up, which it does now.