### PR TITLE
fixed validation of schema for new version

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -15,6 +15,7 @@
         "@emotion/styled": "^11.10.5",
         "@monaco-editor/react": "^4.6.0",
         "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "date-fns": "^2.29.3",
         "global": "^4.4.0",
         "material-react-table": "^1.14.0",
@@ -5450,7 +5451,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -24618,7 +24618,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "requires": {
         "ajv": "^8.0.0"
       }

--- a/src/package.json
+++ b/src/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.10.5",
     "@monaco-editor/react": "^4.6.0",
     "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
     "date-fns": "^2.29.3",
     "global": "^4.4.0",
     "material-react-table": "^1.14.0",

--- a/src/src/pages/capabilities/jsonmetadata/index.js
+++ b/src/src/pages/capabilities/jsonmetadata/index.js
@@ -67,8 +67,8 @@ export function JsonMetadataWithSchemaViewer() {
   };
 
   const checkIfFollowsJsonSchema = (json) => {
-    const Ajv2020 = require("ajv/dist/2020")
-    const addFormats = require('ajv-formats').default;
+    const Ajv2020 = require("ajv/dist/2020");
+    const addFormats = require("ajv-formats").default;
 
     const ajv = new Ajv2020();
     addFormats(ajv);

--- a/src/src/pages/capabilities/jsonmetadata/index.js
+++ b/src/src/pages/capabilities/jsonmetadata/index.js
@@ -8,6 +8,7 @@ import styles from "./jsonmetadata.module.css";
 import PageSection from "../../../components/PageSection";
 import MonacoEditor, { useMonaco } from "@monaco-editor/react";
 import { vs as syntaxStyle } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import Ajv2020 from "ajv/dist/2020";
 
 export function JsonMetadataWithSchemaViewer() {
   const monaco = useMonaco();
@@ -66,16 +67,26 @@ export function JsonMetadataWithSchemaViewer() {
   };
 
   const checkIfFollowsJsonSchema = (json) => {
+    const Ajv2020 = require("ajv/dist/2020")
+    const addFormats = require('ajv-formats').default;
+
+    const ajv = new Ajv2020();
+    addFormats(ajv);
+    const parsed = JSON.parse(schemaString);
     try {
-      const ajv = new Ajv();
-      const validate = ajv.compile(JSON.parse(schemaString));
-      const valid = validate(JSON.parse(json));
-      if (!valid) {
-        setValidationError("Schema Error: " + validate.errors[0].message);
+      const validate = ajv.compile(parsed);
+      try {
+        const valid = validate(JSON.parse(json));
+        if (!valid) {
+          setValidationError("Validation Error: " + validate.errors[0].message);
+        }
+        return valid;
+      } catch (exception) {
+        setValidationError("Validation Exception: " + exception.message);
+        return false;
       }
-      return valid;
     } catch (exception) {
-      setValidationError("Schema Error: " + exception.message);
+      setValidationError("Schema Exception: " + exception.message);
       return false;
     }
   };


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2314

# Additional Review Notes
- Ajv needs to use Ajv2020 in order to work with `"$schema": "https://json-schema.org/draft/2020-12/schema"` 
- `const addFormats = require("ajv-formats").default` added to handle `date-time` datatype