### PR TITLE
Use schema during capability creation and on details view

### DIFF
--- a/src/src/AppContext.js
+++ b/src/src/AppContext.js
@@ -57,8 +57,13 @@ function AppProvider({ children }) {
   const { profileInfo, isLoadedProfile } = useProfile(user);
   const { statsInfo, isLoadedStats } = useStats(user);
 
-  async function addNewCapability(name, description, invitations) {
-    addCapability(name, description, invitations);
+  async function addNewCapability(
+    name,
+    description,
+    invitations,
+    jsonMetadataString,
+  ) {
+    addCapability(name, description, invitations, jsonMetadataString);
     await sleep(3000);
     await loadMyProfile();
   }

--- a/src/src/Utils.js
+++ b/src/src/Utils.js
@@ -39,7 +39,6 @@ export function composeSegmentsUrl(segments) {
 }
 
 export function removeNonRequiredJsonSchemaProperties(jsonSchemaString) {
-
   const jsonSchemaCopy = JSON.parse(jsonSchemaString);
   let newProperties = JSON.parse("{}");
   if (jsonSchemaCopy.required) {

--- a/src/src/Utils.js
+++ b/src/src/Utils.js
@@ -38,13 +38,16 @@ export function composeSegmentsUrl(segments) {
   return url;
 }
 
-export function removeNonRequiredJsonSchemaProperties(jsonSchema) {
-  const jsonSchemaCopy = JSON.parse(jsonSchema);
+export function removeNonRequiredJsonSchemaProperties(jsonSchemaString) {
+
+  const jsonSchemaCopy = JSON.parse(jsonSchemaString);
   let newProperties = JSON.parse("{}");
-  jsonSchemaCopy.required.forEach((requiredProperty) => {
-    newProperties[requiredProperty] =
-      jsonSchemaCopy.properties[requiredProperty];
-  });
-  jsonSchemaCopy.properties = newProperties;
+  if (jsonSchemaCopy.required) {
+    jsonSchemaCopy.required.forEach((requiredProperty) => {
+      newProperties[requiredProperty] =
+        jsonSchemaCopy.properties[requiredProperty];
+    });
+    jsonSchemaCopy.properties = newProperties;
+  }
   return JSON.stringify(jsonSchemaCopy, null, 2);
 }

--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -13,7 +13,12 @@ export function useCapabilities() {
     list.sort((a, b) => a.name.localeCompare(b.name));
   };
 
-  const createCapability = (name, description, invitations) => {
+  const createCapability = (
+    name,
+    description,
+    invitations,
+    jsonMetadataString,
+  ) => {
     addCapability({
       urlSegments: ["capabilities"],
       method: "POST",
@@ -21,6 +26,7 @@ export function useCapabilities() {
         name: name,
         description: description,
         invitees: invitations,
+        jsonMetadata: jsonMetadataString,
       },
     });
   };

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button, ButtonStack } from "@dfds-ui/react-components";
 import { SideSheet, SideSheetContent } from "@dfds-ui/react-components";
 import { Tooltip, TextField } from "@dfds-ui/react-components";
 import styles from "./capabilities.module.css";
 import { Invitations } from "./invitations";
-//import { CapabilityTags } from "./capabilityTags";
+import { CapabilityTagsSubForm } from "./capabilityTags";
 
 export default function NewCapabilityDialog({
   inProgress,
@@ -25,13 +25,8 @@ export default function NewCapabilityDialog({
 
   const [formData, setFormData] = useState(emptyValues);
   const [invitees, setInvitees] = useState([]);
-  /*
-  const [tagFormData, setTagFormData] = useState({});
-
-  useEffect(() => {
-    console.log(tagFormData);
-  }, [tagFormData]);
-  */
+  const [metadataFormData, setMetadataFormData] = useState({});
+  const [validMetadata, setValidMetadata] = useState(false);
 
   const changeName = (e) => {
     e.preventDefault();
@@ -67,11 +62,17 @@ export default function NewCapabilityDialog({
   const canAdd =
     formData.name !== "" &&
     formData.description !== "" &&
+    validMetadata &&
     nameErrorMessage === "";
 
   const handleAddCapabilityClicked = () => {
+    const jsonMetadataString = JSON.stringify(metadataFormData, null, 1);
     if (onAddCapabilityClicked) {
-      onAddCapabilityClicked({ ...formData, invitations: invitees });
+      onAddCapabilityClicked({
+        ...formData,
+        invitations: invitees,
+        jsonMetadataString,
+      });
     }
   };
 
@@ -119,7 +120,12 @@ export default function NewCapabilityDialog({
             setFormData={setFormData}
           />
 
-          {/*<CapabilityTags setTagData={setTagFormData} />*/}
+          <CapabilityTagsSubForm
+            title="Capability Tags"
+            setMetadata={setMetadataFormData}
+            setValidMetadata={setValidMetadata}
+            preexistingFormData={{}}
+          />
 
           <br />
 

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Button, ButtonStack } from "@dfds-ui/react-components";
 import { SideSheet, SideSheetContent } from "@dfds-ui/react-components";
 import { Tooltip, TextField } from "@dfds-ui/react-components";

--- a/src/src/pages/capabilities/capabilityTags/index.js
+++ b/src/src/pages/capabilities/capabilityTags/index.js
@@ -10,20 +10,20 @@ import SelectedCapabilityContext from "../SelectedCapabilityContext";
 
 function shallowEqual(object1, object2) {
   try {
-  const keys1 = Object.keys(object1);
-  const keys2 = Object.keys(object2);
+    const keys1 = Object.keys(object1);
+    const keys2 = Object.keys(object2);
 
-  if (keys1.length !== keys2.length) {
-    return false;
-  }
-
-  for (let key of keys1) {
-    if (object1[key] !== object2[key]) {
+    if (keys1.length !== keys2.length) {
       return false;
     }
-  }
 
-  return true;
+    for (let key of keys1) {
+      if (object1[key] !== object2[key]) {
+        return false;
+      }
+    }
+
+    return true;
   } catch {
     return false;
   }
@@ -58,7 +58,12 @@ const checkIfFollowsJsonSchema = (data, schema) => {
  * This component uses the react-jsonschema-form library to render the form.
  * The schema is fetched from the backend and filtered to only show required fields.
  */
-export function CapabilityTagsSubForm({ title, setMetadata, setValidMetadata, preexistingFormData }) {
+export function CapabilityTagsSubForm({
+  title,
+  setMetadata,
+  setValidMetadata,
+  preexistingFormData,
+}) {
   /*
   const testSchema = {
     title: "Tags",
@@ -89,7 +94,7 @@ export function CapabilityTagsSubForm({ title, setMetadata, setValidMetadata, pr
     } else {
       setValidMetadata(false);
     }
-  };  
+  };
 
   useEffect(() => {
     if (schemaString && schemaString !== "{}") {
@@ -102,9 +107,11 @@ export function CapabilityTagsSubForm({ title, setMetadata, setValidMetadata, pr
       if (schemaString === "{}") {
         const newSchemaString =
           await selfServiceApiClient.getCapabilityJsonMetadataSchema();
-          
+
         setSchemaString(
-          prettifyJsonString(removeNonRequiredJsonSchemaProperties(newSchemaString)),
+          prettifyJsonString(
+            removeNonRequiredJsonSchemaProperties(newSchemaString),
+          ),
         );
       } else {
         // quick hack to change the title of the form, instead of changing the schema itself
@@ -141,8 +148,8 @@ export function CapabilityTagViewer() {
     SelectedCapabilityContext,
   );
 
-  const [ isDirty, setIsDirty ] = useState(false);
-  const [ isValid, setIsValid ] = useState(true);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isValid, setIsValid] = useState(true);
 
   const [formData, setFormData] = useState({});
   const [existingFormData, setExistingFormData] = useState({});
@@ -180,7 +187,7 @@ export function CapabilityTagViewer() {
           preexistingFormData={existingFormData}
         />
 
-        <br/>
+        <br />
 
         <ButtonStack align={"right"}>
           <Button

--- a/src/src/pages/capabilities/capabilityTags/index.js
+++ b/src/src/pages/capabilities/capabilityTags/index.js
@@ -4,16 +4,61 @@ import AppContext from "AppContext";
 import validator from "@rjsf/validator-ajv8";
 import Form from "@rjsf/core";
 import { removeNonRequiredJsonSchemaProperties } from "Utils";
+import { Button, ButtonStack } from "@dfds-ui/react-components";
+import PageSection from "../../../components/PageSection";
+import SelectedCapabilityContext from "../SelectedCapabilityContext";
+
+function shallowEqual(object1, object2) {
+  try {
+  const keys1 = Object.keys(object1);
+  const keys2 = Object.keys(object2);
+
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+
+  for (let key of keys1) {
+    if (object1[key] !== object2[key]) {
+      return false;
+    }
+  }
+
+  return true;
+  } catch {
+    return false;
+  }
+}
+
+const prettifyJsonString = (json) => {
+  return JSON.stringify(JSON.parse(json), null, 2);
+};
+
+const checkIfFollowsJsonSchema = (data, schema) => {
+  const Ajv2020 = require("ajv/dist/2020");
+  const addFormats = require("ajv-formats").default;
+  const ajv = new Ajv2020();
+  addFormats(ajv);
+  try {
+    const parsed = JSON.parse(schema);
+    const validate = ajv.compile(parsed);
+    return validate(data);
+  } catch (exception) {
+    // [andfris] this should never happen, so I am happy with hiding this in the console
+    console.log("Schema Exception: " + exception.message);
+    return false;
+  }
+};
 
 /*
  * This component is responsible for rendering the capability tags form.
  * Whenever data is changed, the entire formData passed to the setTagData function.
- * The setTagData function must be passed from the parent component.
+ * The setMetadata function must be passed from the parent component.
+ * setValidMetadata: called with true if the form data is valid, false otherwise, whenever data changes.
  *
  * This component uses the react-jsonschema-form library to render the form.
  * The schema is fetched from the backend and filtered to only show required fields.
  */
-export function CapabilityTags({ setTagData }) {
+export function CapabilityTagsSubForm({ title, setMetadata, setValidMetadata, preexistingFormData }) {
   /*
   const testSchema = {
     title: "Tags",
@@ -33,25 +78,38 @@ export function CapabilityTags({ setTagData }) {
 
   const { selfServiceApiClient } = useContext(AppContext);
   const [showTagForm, setShowTagForm] = useState(true);
-  const [schemaString, setSchemaString] = useState("");
+  const [schemaString, setSchemaString] = useState("{}");
   const [schema, setSchema] = useState({});
+  const [formData, setFormData] = useState({});
 
-  const prettifyJsonString = (json) => {
-    return JSON.stringify(JSON.parse(json), null, 2);
-  };
+  const validateAndSet = (formData) => {
+    if (checkIfFollowsJsonSchema(formData, schemaString)) {
+      setValidMetadata(true);
+      setMetadata(formData);
+    } else {
+      setValidMetadata(false);
+    }
+  };  
+
+  useEffect(() => {
+    if (schemaString && schemaString !== "{}") {
+      validateAndSet(formData);
+    }
+  }, [formData, schemaString]);
 
   useEffect(() => {
     async function getAndSetSchema() {
-      if (schemaString === "") {
-        const schema =
+      if (schemaString === "{}") {
+        const newSchemaString =
           await selfServiceApiClient.getCapabilityJsonMetadataSchema();
+          
         setSchemaString(
-          prettifyJsonString(removeNonRequiredJsonSchemaProperties(schema)),
+          prettifyJsonString(removeNonRequiredJsonSchemaProperties(newSchemaString)),
         );
       } else {
-        // quick hack to change the title of the form, instead of changing the schema
+        // quick hack to change the title of the form, instead of changing the schema itself
         var updated_schema = JSON.parse(schemaString);
-        updated_schema["title"] = "Capability Tags";
+        updated_schema["title"] = title;
         setSchema(updated_schema);
         setShowTagForm(true);
       }
@@ -65,13 +123,76 @@ export function CapabilityTags({ setTagData }) {
         <Form
           schema={schema}
           validator={validator}
-          onChange={(type) => setTagData(type.formData)}
+          onChange={(type) => setFormData(type.formData)}
+          formData={preexistingFormData}
           children={true} // hide submit button
         />
       ) : (
         // [andfris] let's see if we need a spinner
         <p>Loading tag requirements</p>
       )}
+    </>
+  );
+}
+
+export function CapabilityTagViewer() {
+  // does set update the backend? How is this done in the metadata view?
+  const { metadata, setCapabilityJsonMetadata } = useContext(
+    SelectedCapabilityContext,
+  );
+
+  const [ isDirty, setIsDirty ] = useState(false);
+  const [ isValid, setIsValid ] = useState(true);
+
+  const [formData, setFormData] = useState({});
+  const [existingFormData, setExistingFormData] = useState({});
+
+  useEffect(() => {
+    if (metadata && metadata !== "{}") {
+      setExistingFormData(JSON.parse(metadata));
+    }
+
+    if (shallowEqual(formData, existingFormData)) {
+      setIsDirty(false);
+    } else {
+      setIsDirty(true);
+    }
+  }, [formData, metadata]);
+
+  const submitTags = (formdata) => {
+    // do not override non-required metadata fields, should they exist
+    var mergedMetaData = { ...existingFormData };
+    Object.keys(formdata).forEach((key) => {
+      mergedMetaData[key] = formdata[key];
+    });
+
+    setCapabilityJsonMetadata(JSON.stringify(mergedMetaData));
+    setIsDirty(false);
+  };
+
+  return (
+    <>
+      <PageSection headline="Capability Tags">
+        <CapabilityTagsSubForm
+          title=""
+          setMetadata={setFormData}
+          setValidMetadata={setIsValid}
+          preexistingFormData={existingFormData}
+        />
+
+        <br/>
+
+        <ButtonStack align={"right"}>
+          <Button
+            size="small"
+            variation="outlined"
+            onClick={() => submitTags(formData)}
+            disabled={!(isValid && isDirty)}
+          >
+            Submit
+          </Button>
+        </ButtonStack>
+      </PageSection>
     </>
   );
 }

--- a/src/src/pages/capabilities/details.js
+++ b/src/src/pages/capabilities/details.js
@@ -13,6 +13,7 @@ import DeletionWarning from "./deletionWarning";
 import CapabilityManagement from "./capabilityManagement";
 import { CapabilityInvitations } from "./capabilityInvitations/capabilityInvitations";
 import { JsonMetadataWithSchemaViewer } from "./jsonmetadata";
+import { CapabilityTagViewer } from "./capabilityTags";
 
 export default function CapabilityDetailsPage() {
   return (
@@ -77,6 +78,9 @@ function CapabilityDetailsPageContent() {
       <Page title={pagetitle} isLoading={isLoading} isNotFound={!isFound}>
         <Members />
         <Summary />
+
+        <CapabilityTagViewer />
+
         {showJsonMetadata && <JsonMetadataWithSchemaViewer />}
         <Resources capabilityId={id} />
 

--- a/src/src/pages/capabilities/index.js
+++ b/src/src/pages/capabilities/index.js
@@ -27,6 +27,7 @@ export default function CapabilitiesPage() {
       formData.name,
       formData.description,
       formData.invitations,
+      formData.jsonMetadataString,
     );
     setShowNewCapabilityDialog(false);
     setIsCreatingNewCapability(false);


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2362

# Additional Review Notes
Capability auto reload is still broken, but is covered in another ticket (#2284).
As such I have not looked into that here, even though it very much is an issue.

Hopefully this is reusable and generic enough to serve for a while.