### PR TITLE
refactored json schema fetching and using

### DIFF
--- a/src/src/JsonSchemaContext.js
+++ b/src/src/JsonSchemaContext.js
@@ -1,0 +1,61 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import {
+  prettifyJsonString,
+  removeNonRequiredJsonSchemaProperties,
+  shallowEqual,
+} from "./Utils";
+import AppContext from "./AppContext";
+
+const JsonSchemaContext = createContext();
+
+function JsonSchemaProvider({ children }) {
+  const { selfServiceApiClient } = useContext(AppContext);
+
+  const [fetchJsonSchema, setFetchJsonSchema] = useState(true);
+  const [jsonSchema, setJsonSchema] = useState({});
+  const [jsonSchemaString, setJsonSchemaString] = useState("{}");
+  const [filteredJsonSchema, setFilteredJsonSchema] = useState({});
+  const [filteredJsonSchemaString, setFilteredJsonSchemaString] =
+    useState("{}");
+  const [hasFilteredJsonSchema, setHasFilteredJsonSchema] = useState(false);
+
+  useEffect(() => {
+    async function fetchData() {
+      setFetchJsonSchema(false);
+      const fetchedSchema =
+        await selfServiceApiClient.getCapabilityJsonMetadataSchema();
+      setJsonSchemaString(prettifyJsonString(fetchedSchema));
+      setJsonSchema(JSON.parse(fetchedSchema));
+      const filtered = removeNonRequiredJsonSchemaProperties(fetchedSchema);
+      const schemaObject = JSON.parse(filtered);
+
+      if (!shallowEqual(schemaObject.properties, {})) {
+        schemaObject["title"] = ""; // do not render title from schema
+        setHasFilteredJsonSchema(true);
+        setFilteredJsonSchema(schemaObject);
+        const prettified = prettifyJsonString(JSON.stringify(schemaObject));
+        setFilteredJsonSchemaString(prettified);
+      }
+    }
+
+    if (fetchJsonSchema) {
+      void fetchData();
+    }
+  }, [fetchJsonSchema]);
+
+  return (
+    <JsonSchemaContext.Provider
+      value={{
+        jsonSchema,
+        jsonSchemaString,
+        filteredJsonSchema,
+        filteredJsonSchemaString,
+        hasFilteredJsonSchema,
+      }}
+    >
+      {children}
+    </JsonSchemaContext.Provider>
+  );
+}
+
+export { JsonSchemaContext as default, JsonSchemaProvider };

--- a/src/src/Utils.js
+++ b/src/src/Utils.js
@@ -52,3 +52,28 @@ export function removeNonRequiredJsonSchemaProperties(jsonSchemaString) {
   }
   return JSON.stringify(jsonSchemaCopy, null, 2);
 }
+
+export function shallowEqual(object1, object2) {
+  try {
+    const keys1 = Object.keys(object1);
+    const keys2 = Object.keys(object2);
+
+    if (keys1.length !== keys2.length) {
+      return false;
+    }
+
+    for (let key of keys1) {
+      if (object1[key] !== object2[key]) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function prettifyJsonString(json) {
+  return JSON.stringify(JSON.parse(json), null, 2);
+}

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -4,7 +4,8 @@ import { SideSheet, SideSheetContent } from "@dfds-ui/react-components";
 import { Tooltip, TextField } from "@dfds-ui/react-components";
 import styles from "./capabilities.module.css";
 import { Invitations } from "./invitations";
-import { CapabilityTagsSubForm } from "./capabilityTags";
+import { CapabilityTagsSubForm } from "./capabilityTags/capabilityTagsSubForm";
+import JsonSchemaContext, { JsonSchemaProvider } from "../../JsonSchemaContext";
 
 export default function NewCapabilityDialog({
   inProgress,
@@ -120,13 +121,15 @@ export default function NewCapabilityDialog({
             setFormData={setFormData}
           />
 
-          <CapabilityTagsSubForm
-            label="Capability Tags"
-            setMetadata={setMetadataFormData}
-            setHasSchema={() => {}}
-            setValidMetadata={setValidMetadata}
-            preexistingFormData={{}}
-          />
+          <JsonSchemaProvider>
+            <CapabilityTagsSubForm
+              label="Capability Tags"
+              setMetadata={setMetadataFormData}
+              setHasSchema={() => {}}
+              setValidMetadata={setValidMetadata}
+              preexistingFormData={{}}
+            />
+          </JsonSchemaProvider>
 
           <br />
 

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -5,7 +5,7 @@ import { Tooltip, TextField } from "@dfds-ui/react-components";
 import styles from "./capabilities.module.css";
 import { Invitations } from "./invitations";
 import { CapabilityTagsSubForm } from "./capabilityTags/capabilityTagsSubForm";
-import JsonSchemaContext, { JsonSchemaProvider } from "../../JsonSchemaContext";
+import { JsonSchemaProvider } from "../../JsonSchemaContext";
 
 export default function NewCapabilityDialog({
   inProgress,

--- a/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
@@ -1,0 +1,107 @@
+/*
+ * This component is responsible for rendering the capability tags form.
+ * Whenever data is changed, the entire formData passed to the setTagData function.
+ * The setMetadata function must be passed from the parent component.
+ * setValidMetadata: called with true if the form data is valid, false otherwise, whenever data changes.
+ *
+ * This component uses the react-jsonschema-form library to render the form.
+ * The schema is fetched from the backend and filtered to only show required fields.
+ */
+import React, { useContext, useEffect, useState } from "react";
+import { Text } from "@dfds-ui/react-components";
+import styles from "./capabilityTags.module.css";
+import Form from "@rjsf/core";
+import validator from "@rjsf/validator-ajv8";
+import Select from "react-select";
+import JsonSchemaContext from "../../../JsonSchemaContext";
+
+/*
+ * Custom Widgets and Fields
+ */
+
+const CustomDropdown = function (props) {
+  const { options, value, onChange } = props;
+  return (
+    <Select
+      value={options.enumOptions.find((o) => o.value === value)}
+      options={options.enumOptions}
+      clearable={false}
+      onChange={(o) => onChange(o.value)}
+    />
+  );
+};
+
+const checkIfFollowsJsonSchema = (data, schema) => {
+  const Ajv2020 = require("ajv/dist/2020");
+  const addFormats = require("ajv-formats").default;
+  const ajv = new Ajv2020();
+  addFormats(ajv);
+  try {
+    const parsed = JSON.parse(schema);
+    const validate = ajv.compile(parsed);
+    return validate(data);
+  } catch (exception) {
+    // [andfris] this should never happen, so I am happy with hiding this in the console
+    console.log("Schema Exception: " + exception.message);
+    return false;
+  }
+};
+
+export function CapabilityTagsSubForm({
+  label,
+  setMetadata,
+  setValidMetadata,
+  preexistingFormData,
+}) {
+  const {
+    hasFilteredJsonSchema,
+    filteredJsonSchema,
+    filteredJsonSchemaString,
+  } = useContext(JsonSchemaContext);
+  const [showTagForm, setShowTagForm] = useState(false);
+  const [formData, setFormData] = useState({});
+
+  const validateAndSet = (formData) => {
+    if (checkIfFollowsJsonSchema(formData, filteredJsonSchemaString)) {
+      setValidMetadata(true);
+      setMetadata(formData);
+    } else {
+      setValidMetadata(false);
+    }
+  };
+
+  useEffect(() => {
+    if (hasFilteredJsonSchema) {
+      validateAndSet(formData);
+    }
+  }, [formData, filteredJsonSchemaString]);
+
+  useEffect(() => {
+    if (hasFilteredJsonSchema) {
+      setShowTagForm(true);
+    }
+  }, [hasFilteredJsonSchema]);
+
+  const widgets = {
+    SelectWidget: CustomDropdown,
+  };
+
+  return (
+    <>
+      {showTagForm && (
+        <>
+          {label !== "" && <Text className={styles.label}>{label}</Text>}
+          <Form
+            className={styles.tagsform}
+            schema={filteredJsonSchema}
+            validator={validator}
+            onChange={(type) => setFormData(type.formData)}
+            widgets={widgets}
+            formData={preexistingFormData}
+            children={true} // hide submit button
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/src/src/pages/capabilities/capabilityTags/index.js
+++ b/src/src/pages/capabilities/capabilityTags/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext, useState } from "react";
 import { shallowEqual } from "Utils";
-import { Button, ButtonStack, Text } from "@dfds-ui/react-components";
+import { Button, ButtonStack } from "@dfds-ui/react-components";
 import PageSection from "../../../components/PageSection";
 import SelectedCapabilityContext from "../SelectedCapabilityContext";
 import { CapabilityTagsSubForm } from "./capabilityTagsSubForm";

--- a/src/src/pages/capabilities/capabilityTags/index.js
+++ b/src/src/pages/capabilities/capabilityTags/index.js
@@ -3,163 +3,27 @@ import styles from "./capabilityTags.module.css";
 import AppContext from "AppContext";
 import validator from "@rjsf/validator-ajv8";
 import Form from "@rjsf/core";
-import { removeNonRequiredJsonSchemaProperties } from "Utils";
+import {
+  removedNonRequiredJsonSchemaProperties,
+  removeNonRequiredJsonSchemaProperties,
+  shallowEqual,
+} from "Utils";
 import { Button, ButtonStack, Text } from "@dfds-ui/react-components";
 import PageSection from "../../../components/PageSection";
 import SelectedCapabilityContext from "../SelectedCapabilityContext";
 import Select from "react-select";
-
-function shallowEqual(object1, object2) {
-  try {
-    const keys1 = Object.keys(object1);
-    const keys2 = Object.keys(object2);
-
-    if (keys1.length !== keys2.length) {
-      return false;
-    }
-
-    for (let key of keys1) {
-      if (object1[key] !== object2[key]) {
-        return false;
-      }
-    }
-
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-const prettifyJsonString = (json) => {
-  return JSON.stringify(JSON.parse(json), null, 2);
-};
-
-const checkIfFollowsJsonSchema = (data, schema) => {
-  const Ajv2020 = require("ajv/dist/2020");
-  const addFormats = require("ajv-formats").default;
-  const ajv = new Ajv2020();
-  addFormats(ajv);
-  try {
-    const parsed = JSON.parse(schema);
-    const validate = ajv.compile(parsed);
-    return validate(data);
-  } catch (exception) {
-    // [andfris] this should never happen, so I am happy with hiding this in the console
-    console.log("Schema Exception: " + exception.message);
-    return false;
-  }
-};
-
-/*
- * Custom Widgets and Fields
- */
-
-const CustomDropdown = function (props) {
-  const { options, value, onChange } = props;
-  return (
-    <Select
-      value={options.enumOptions.find((o) => o.value === value)}
-      options={options.enumOptions}
-      clearable={false}
-      onChange={(o) => onChange(o.value)}
-    />
-  );
-};
-
-/*
- * This component is responsible for rendering the capability tags form.
- * Whenever data is changed, the entire formData passed to the setTagData function.
- * The setMetadata function must be passed from the parent component.
- * setValidMetadata: called with true if the form data is valid, false otherwise, whenever data changes.
- *
- * This component uses the react-jsonschema-form library to render the form.
- * The schema is fetched from the backend and filtered to only show required fields.
- */
-export function CapabilityTagsSubForm({
-  label,
-  setMetadata,
-  setHasSchema,
-  setValidMetadata,
-  preexistingFormData,
-}) {
-  const { selfServiceApiClient } = useContext(AppContext);
-  const [showTagForm, setShowTagForm] = useState(false);
-  const [schemaString, setSchemaString] = useState("{}");
-  const [schema, setSchema] = useState({});
-  const [formData, setFormData] = useState({});
-
-  const validateAndSet = (formData) => {
-    if (checkIfFollowsJsonSchema(formData, schemaString)) {
-      setValidMetadata(true);
-      setMetadata(formData);
-    } else {
-      setValidMetadata(false);
-    }
-  };
-
-  useEffect(() => {
-    if (schemaString && schemaString !== "{}") {
-      validateAndSet(formData);
-    }
-  }, [formData, schemaString]);
-
-  useEffect(() => {
-    async function getAndSetSchema() {
-      if (schemaString === "{}") {
-        const newSchemaString =
-          await selfServiceApiClient.getCapabilityJsonMetadataSchema();
-
-        setSchemaString(
-          prettifyJsonString(
-            removeNonRequiredJsonSchemaProperties(newSchemaString),
-          ),
-        );
-      } else {
-        var updated_schema = JSON.parse(schemaString);
-        updated_schema["title"] = ""; // do not render title from schema
-        if (!shallowEqual(updated_schema.properties, {})) {
-          setSchema(updated_schema);
-          setHasSchema(true);
-          setShowTagForm(true);
-        }
-      }
-    }
-    void getAndSetSchema();
-  }, [schemaString]);
-
-  const widgets = {
-    SelectWidget: CustomDropdown,
-  };
-
-  return (
-    <>
-      {showTagForm && (
-        <>
-          {label !== "" && <Text className={styles.label}>{label}</Text>}
-          <Form
-            className={styles.tagsform}
-            schema={schema}
-            validator={validator}
-            onChange={(type) => setFormData(type.formData)}
-            widgets={widgets}
-            formData={preexistingFormData}
-            children={true} // hide submit button
-          />
-        </>
-      )}
-    </>
-  );
-}
+import { CapabilityTagsSubForm } from "./capabilityTagsSubForm";
+import JsonSchemaContext from "../../../JsonSchemaContext";
 
 export function CapabilityTagViewer() {
   // does set update the backend? How is this done in the metadata view?
   const { metadata, setCapabilityJsonMetadata } = useContext(
     SelectedCapabilityContext,
   );
+  const { hasFilteredJsonSchema } = useContext(JsonSchemaContext);
 
   const [isDirty, setIsDirty] = useState(false);
   const [isValid, setIsValid] = useState(true);
-  const [hasSchema, setHasSchema] = useState(false);
   const [formData, setFormData] = useState({});
   const [existingFormData, setExistingFormData] = useState({});
 
@@ -187,13 +51,12 @@ export function CapabilityTagViewer() {
   };
 
   return (
-    hasSchema && (
+    hasFilteredJsonSchema && (
       <>
         <PageSection headline="Capability Tags">
           <CapabilityTagsSubForm
             title=""
             setMetadata={setFormData}
-            setHasSchema={setHasSchema}
             setValidMetadata={setIsValid}
             preexistingFormData={existingFormData}
           />

--- a/src/src/pages/capabilities/capabilityTags/index.js
+++ b/src/src/pages/capabilities/capabilityTags/index.js
@@ -1,17 +1,8 @@
 import React, { useEffect, useContext, useState } from "react";
-import styles from "./capabilityTags.module.css";
-import AppContext from "AppContext";
-import validator from "@rjsf/validator-ajv8";
-import Form from "@rjsf/core";
-import {
-  removedNonRequiredJsonSchemaProperties,
-  removeNonRequiredJsonSchemaProperties,
-  shallowEqual,
-} from "Utils";
+import { shallowEqual } from "Utils";
 import { Button, ButtonStack, Text } from "@dfds-ui/react-components";
 import PageSection from "../../../components/PageSection";
 import SelectedCapabilityContext from "../SelectedCapabilityContext";
-import Select from "react-select";
 import { CapabilityTagsSubForm } from "./capabilityTagsSubForm";
 import JsonSchemaContext from "../../../JsonSchemaContext";
 

--- a/src/src/pages/capabilities/details.js
+++ b/src/src/pages/capabilities/details.js
@@ -14,12 +14,15 @@ import CapabilityManagement from "./capabilityManagement";
 import { CapabilityInvitations } from "./capabilityInvitations/capabilityInvitations";
 import { JsonMetadataWithSchemaViewer } from "./jsonmetadata";
 import { CapabilityTagViewer } from "./capabilityTags";
+import JsonSchemaContext, { JsonSchemaProvider } from "../../JsonSchemaContext";
 
 export default function CapabilityDetailsPage() {
   return (
     <>
       <SelectedCapabilityProvider>
-        <CapabilityDetailsPageContent />
+        <JsonSchemaProvider>
+          <CapabilityDetailsPageContent />
+        </JsonSchemaProvider>
       </SelectedCapabilityProvider>
     </>
   );

--- a/src/src/pages/capabilities/details.js
+++ b/src/src/pages/capabilities/details.js
@@ -14,7 +14,7 @@ import CapabilityManagement from "./capabilityManagement";
 import { CapabilityInvitations } from "./capabilityInvitations/capabilityInvitations";
 import { JsonMetadataWithSchemaViewer } from "./jsonmetadata";
 import { CapabilityTagViewer } from "./capabilityTags";
-import JsonSchemaContext, { JsonSchemaProvider } from "../../JsonSchemaContext";
+import { JsonSchemaProvider } from "../../JsonSchemaContext";
 
 export default function CapabilityDetailsPage() {
   return (


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2406

# Additional Review Notes
Issue was that fetching of the json schema happened inside of CapabilityTagsSubForm component, but this component was never shown (get executed), because no json schema was set:
```
 return (
    hasSchema && (
      <>
        <PageSection headline="Capability Tags">
          <CapabilityTagsSubForm
            title=""
            setMetadata={setFormData}
            setHasSchema={setHasSchema}
            setValidMetadata={setIsValid}
            preexistingFormData={existingFormData}
          />
``` 

I have moved json schema fetching and filtering into its own context that now replaces manual fetching around

Tested with:
- No schema
- Schema with no required properties
- Schema with required properties