### PR TITLE
Allow optional tags

### DIFF
--- a/src/src/JsonSchemaContext.js
+++ b/src/src/JsonSchemaContext.js
@@ -1,9 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import {
-  prettifyJsonString,
-  removeNonRequiredJsonSchemaProperties,
-  shallowEqual,
-} from "./Utils";
+import { prettifyJsonString, shallowEqual } from "./Utils";
 import AppContext from "./AppContext";
 
 const JsonSchemaContext = createContext();
@@ -14,27 +10,20 @@ function JsonSchemaProvider({ children }) {
   const [fetchJsonSchema, setFetchJsonSchema] = useState(true);
   const [jsonSchema, setJsonSchema] = useState({});
   const [jsonSchemaString, setJsonSchemaString] = useState("{}");
-  const [filteredJsonSchema, setFilteredJsonSchema] = useState({});
-  const [filteredJsonSchemaString, setFilteredJsonSchemaString] =
-    useState("{}");
-  const [hasFilteredJsonSchema, setHasFilteredJsonSchema] = useState(false);
+  const [hasJsonSchemaProperties, setHasJsonSchemaProperties] = useState(false);
 
   useEffect(() => {
     async function fetchData() {
       setFetchJsonSchema(false);
       const fetchedSchema =
         await selfServiceApiClient.getCapabilityJsonMetadataSchema();
+      var schemaObject = JSON.parse(fetchedSchema);
+      schemaObject["title"] = ""; // do not render title from schema
       setJsonSchemaString(prettifyJsonString(fetchedSchema));
-      setJsonSchema(JSON.parse(fetchedSchema));
-      const filtered = removeNonRequiredJsonSchemaProperties(fetchedSchema);
-      const schemaObject = JSON.parse(filtered);
+      setJsonSchema(schemaObject);
 
       if (!shallowEqual(schemaObject.properties, {})) {
-        schemaObject["title"] = ""; // do not render title from schema
-        setHasFilteredJsonSchema(true);
-        setFilteredJsonSchema(schemaObject);
-        const prettified = prettifyJsonString(JSON.stringify(schemaObject));
-        setFilteredJsonSchemaString(prettified);
+        setHasJsonSchemaProperties(true);
       }
     }
 
@@ -48,9 +37,7 @@ function JsonSchemaProvider({ children }) {
       value={{
         jsonSchema,
         jsonSchemaString,
-        filteredJsonSchema,
-        filteredJsonSchemaString,
-        hasFilteredJsonSchema,
+        hasJsonSchemaProperties,
       }}
     >
       {children}

--- a/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
@@ -104,16 +104,13 @@ export function CapabilityTagsSubForm({
   setValidMetadata,
   preexistingFormData,
 }) {
-  const {
-    hasFilteredJsonSchema,
-    filteredJsonSchema,
-    filteredJsonSchemaString,
-  } = useContext(JsonSchemaContext);
+  const { jsonSchema, jsonSchemaString, hasJsonSchemaProperties } =
+    useContext(JsonSchemaContext);
   const [showTagForm, setShowTagForm] = useState(false);
   const [formData, setFormData] = useState({});
 
   const validateAndSet = (formData) => {
-    if (checkIfFollowsJsonSchema(formData, filteredJsonSchemaString)) {
+    if (checkIfFollowsJsonSchema(formData, jsonSchemaString)) {
       setValidMetadata(true);
       setMetadata(formData);
     } else {
@@ -122,19 +119,19 @@ export function CapabilityTagsSubForm({
   };
 
   useEffect(() => {
-    if (hasFilteredJsonSchema) {
+    if (hasJsonSchemaProperties) {
       validateAndSet(formData);
     }
   }, [formData]);
 
   useEffect(() => {
-    if (hasFilteredJsonSchema) {
+    if (hasJsonSchemaProperties) {
       setValidMetadata(false);
       setShowTagForm(true);
     } else {
       setValidMetadata(true);
     }
-  }, [hasFilteredJsonSchema]);
+  }, [hasJsonSchemaProperties]);
 
   const widgets = {
     SelectWidget: CustomDropdown,
@@ -157,7 +154,7 @@ export function CapabilityTagsSubForm({
           </a>
           <Form
             className={styles.tagsform}
-            schema={filteredJsonSchema}
+            schema={jsonSchema}
             validator={validator}
             onChange={(type) => setFormData(type.formData)}
             widgets={widgets}

--- a/src/src/pages/capabilities/capabilityTags/index.js
+++ b/src/src/pages/capabilities/capabilityTags/index.js
@@ -11,7 +11,7 @@ export function CapabilityTagViewer() {
   const { metadata, setRequiredCapabilityJsonMetadata, links } = useContext(
     SelectedCapabilityContext,
   );
-  const { hasFilteredJsonSchema } = useContext(JsonSchemaContext);
+  const { hasJsonSchemaProperties } = useContext(JsonSchemaContext);
   const [canEditJsonMetadata, setCanEditJsonMetadata] = useState(false);
 
   const [isDirty, setIsDirty] = useState(false);
@@ -49,7 +49,7 @@ export function CapabilityTagViewer() {
   };
 
   return (
-    hasFilteredJsonSchema &&
+    hasJsonSchemaProperties &&
     canEditJsonMetadata && (
       <>
         <PageSection headline="Capability Tags">


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2500

This is a draft, as it is just a suggestion still.
Further we should not roll this out until the underlying schema is in the right state.

Changes:
Render all tagging json schema properties instead of just required.
Required fields still block creation or updating, when not set.

This is a very simple way to keep some tags optional without changing their values.

Further work susggestions:
- Structure the tagging form to group required and optional tags.
- Have some text indicating what is missing before being able to click 'add' under New Capabilities.

![Screenshot 2024-01-22 095417](https://github.com/dfds/selfservice-portal/assets/177252/362c1e68-83cf-4b33-8722-f8f4d96573a5)
