### PR TITLE
Initial design for feedback

### DIFF
--- a/src/src/pages/capabilities/SelectedCapabilityContext.js
+++ b/src/src/pages/capabilities/SelectedCapabilityContext.js
@@ -18,6 +18,7 @@ import {
 
 import { getAnotherUserProfilePictureUrl } from "../../GraphApiClient";
 import { useDeleteTopic, useUpdateTopic } from "../../hooks/Topics";
+import { useSelfServiceRequest } from "hooks/SelfServiceApi";
 
 const SelectedCapabilityContext = createContext();
 
@@ -59,8 +60,24 @@ function SelectedCapabilityProvider({ children }) {
     useCapabilityMembersApplications(details);
   const { addInvitees } = useCapabilityInvitees(details);
   const [isInviteesCreated, setIsInviteesCreated] = useState(false);
-  const [adoptionLevelInformation, setAdoptionLevelInformation] =
-    useState(null);
+
+  const configurationLevelLink = details?._links?.configurationLevel?.href;
+  const {
+    responseData: configurationLevelInformation,
+    sendRequest: getConfiguraitionLevelInformation,
+  } = useSelfServiceRequest();
+  const loadConfigurationLevelInformation = () => {
+    if (configurationLevelLink) {
+      getConfiguraitionLevelInformation({
+        urlSegments: [configurationLevelLink],
+      });
+    }
+  };
+  useEffect(() => {
+    if (!configurationLevelInformation && configurationLevelLink) {
+      loadConfigurationLevelInformation();
+    }
+  }, [configurationLevelInformation, configurationLevelLink]);
 
   function sleep(duration) {
     return new Promise((resolve) => {
@@ -438,38 +455,6 @@ function SelectedCapabilityProvider({ children }) {
     }
   }, [awsAccountRequested]);
 
-  useEffect(() => {}, []);
-
-  useEffect(() => {
-    const dummyData = {
-      overallAdoptionLevel: "PARTIAL",
-      metrics: [
-        {
-          description: "Public topics with schemas",
-          suggestion: "Create chemas for all public topics",
-          isFocusMetric: true,
-          level: "PARTIAL",
-        },
-        {
-          description: "Indicate cost centre for capability",
-          suggestion: "Set the dfds.cost.centre tag for this capability",
-          isFocusMetric: true,
-          level: "COMPLETE",
-        },
-        {
-          description: "Indicate capability criticality",
-          suggestion: "Set the right tags",
-          isFocusMetric: false,
-          level: "NONE",
-        },
-      ],
-    };
-
-    if (!adoptionLevelInformation) {
-      setAdoptionLevelInformation(dummyData);
-    }
-  }, [adoptionLevelInformation]);
-
   //--------------------------------------------------------------------
 
   const state = {
@@ -510,7 +495,7 @@ function SelectedCapabilityProvider({ children }) {
     setRequiredCapabilityJsonMetadata,
     metadata,
     validateContract,
-    adoptionLevelInformation,
+    configurationLevelInformation,
   };
 
   return (

--- a/src/src/pages/capabilities/SelectedCapabilityContext.js
+++ b/src/src/pages/capabilities/SelectedCapabilityContext.js
@@ -59,6 +59,8 @@ function SelectedCapabilityProvider({ children }) {
     useCapabilityMembersApplications(details);
   const { addInvitees } = useCapabilityInvitees(details);
   const [isInviteesCreated, setIsInviteesCreated] = useState(false);
+  const [adoptionLevelInformation, setAdoptionLevelInformation] =
+    useState(null);
 
   function sleep(duration) {
     return new Promise((resolve) => {
@@ -438,6 +440,36 @@ function SelectedCapabilityProvider({ children }) {
 
   useEffect(() => {}, []);
 
+  useEffect(() => {
+    const dummyData = {
+      overallAdoptionLevel: "PARTIAL",
+      metrics: [
+        {
+          description: "Public topics with schemas",
+          suggestion: "Create chemas for all public topics",
+          isFocusMetric: true,
+          level: "PARTIAL",
+        },
+        {
+          description: "Indicate cost centre for capability",
+          suggestion: "Set the dfds.cost.centre tag for this capability",
+          isFocusMetric: true,
+          level: "COMPLETE",
+        },
+        {
+          description: "Indicate capability criticality",
+          suggestion: "Set the right tags",
+          isFocusMetric: false,
+          level: "NONE",
+        },
+      ],
+    };
+
+    if (!adoptionLevelInformation) {
+      setAdoptionLevelInformation(dummyData);
+    }
+  }, [adoptionLevelInformation]);
+
   //--------------------------------------------------------------------
 
   const state = {
@@ -478,6 +510,7 @@ function SelectedCapabilityProvider({ children }) {
     setRequiredCapabilityJsonMetadata,
     metadata,
     validateContract,
+    adoptionLevelInformation,
   };
 
   return (

--- a/src/src/pages/capabilities/capabilityAdoptionLevel/capabilityAdoptionLevel.module.css
+++ b/src/src/pages/capabilities/capabilityAdoptionLevel/capabilityAdoptionLevel.module.css
@@ -18,6 +18,7 @@
 
 .metricRowTextWrapper {
   height: 100%;
+  width: 80%;
   line-height: 100%;
   display: inline-block;
   vertical-align: middle;
@@ -30,24 +31,24 @@
 }
 
 .levelIndicator {
-    margin-right: 15px;
-    display: inline-block;
+  margin-right: 15px;
+  display: inline-block;
 }
 
 .levelIndicatorIcon {
-    width: 25px;
-    height: 25px;
-    color: grey;
+  width: 25px;
+  height: 25px;
+  color: grey;
 }
 
 .completeAdoption {
-    color: #4cb443;
+  color: #4cb443;
 }
 .partialAdoption {
-    color: orange;
+  color: orange;
 }
 .noAdoption {
-    color: brown;
+  color: brown;
 }
 
 .metricRowSuggestion {

--- a/src/src/pages/capabilities/capabilityAdoptionLevel/capabilityAdoptionLevel.module.css
+++ b/src/src/pages/capabilities/capabilityAdoptionLevel/capabilityAdoptionLevel.module.css
@@ -21,44 +21,37 @@
   line-height: 100%;
   display: inline-block;
   vertical-align: middle;
-  margin-top: -15px;
 }
 
 .metricRowText {
   width: 100%;
   display: inline-block;
-}
-
-.metricRowSuggestion {
-  line-height: 0.8em;
-  font-size: 0.8em;
+  font-size: 1.1em;
 }
 
 .levelIndicator {
-  width: 25px;
-  height: 25px;
-  border-radius: 50%;
-  display: inline-block;
-  background-color: grey;
-  border-color: #a0a0a0;
-  box-shadow: 0px 0px 10px 1px grey;
-  margin-right: 15px;
+    margin-right: 15px;
+    display: inline-block;
 }
 
-.complete {
-  background-color: #4cb443;
-  border-color: #3c8d35;
-  box-shadow: 0px 0px 10px 1px #4cb443;
+.levelIndicatorIcon {
+    width: 25px;
+    height: 25px;
+    color: grey;
 }
 
-.partial {
-  background-color: orange;
-  border-color: rgb(187, 122, 1);
-  box-shadow: 0px 0px 10px 1px orange;
+.completeAdoption {
+    color: #4cb443;
+}
+.partialAdoption {
+    color: orange;
+}
+.noAdoption {
+    color: brown;
 }
 
-.none {
-  background-color: brown;
-  border-color: rgb(145, 38, 38);
-  box-shadow: 0px 0px 10px 1px brown;
+.metricRowSuggestion {
+  line-height: 0.9em;
+  font-size: 0.9em;
+  color: rgb(122, 122, 122);
 }

--- a/src/src/pages/capabilities/capabilityAdoptionLevel/capabilityAdoptionLevel.module.css
+++ b/src/src/pages/capabilities/capabilityAdoptionLevel/capabilityAdoptionLevel.module.css
@@ -1,0 +1,64 @@
+.columnWrapper {
+  width: 100%;
+  display: flex;
+}
+
+.column {
+  width: 50%;
+  display: inline-block;
+}
+
+.metricRow {
+  margin-bottom: 15px;
+  display: inline-block;
+  width: 100%;
+  line-height: 25px;
+  vertical-align: middle;
+}
+
+.metricRowTextWrapper {
+  height: 100%;
+  line-height: 100%;
+  display: inline-block;
+  vertical-align: middle;
+  margin-top: -15px;
+}
+
+.metricRowText {
+  width: 100%;
+  display: inline-block;
+}
+
+.metricRowSuggestion {
+  line-height: 0.8em;
+  font-size: 0.8em;
+}
+
+.levelIndicator {
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  display: inline-block;
+  background-color: grey;
+  border-color: #a0a0a0;
+  box-shadow: 0px 0px 10px 1px grey;
+  margin-right: 15px;
+}
+
+.complete {
+  background-color: #4cb443;
+  border-color: #3c8d35;
+  box-shadow: 0px 0px 10px 1px #4cb443;
+}
+
+.partial {
+  background-color: orange;
+  border-color: rgb(187, 122, 1);
+  box-shadow: 0px 0px 10px 1px orange;
+}
+
+.none {
+  background-color: brown;
+  border-color: rgb(145, 38, 38);
+  box-shadow: 0px 0px 10px 1px brown;
+}

--- a/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
+++ b/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
@@ -1,15 +1,20 @@
 import React, { useEffect, useContext, useState } from "react";
 import PageSection from "../../../components/PageSection";
-import SelectedCapabilityContext from "../SelectedCapabilityContext";
 import styles from "./capabilityAdoptionLevel.module.css";
 import { Text } from "@dfds-ui/typography";
-import { StatusSuccess, StatusAlert, Information, Help } from "@dfds-ui/icons/system";
+import {
+  StatusSuccess,
+  StatusAlert,
+  Information,
+  Help,
+} from "@dfds-ui/icons/system";
+import SelectedCapabilityContext from "../SelectedCapabilityContext";
 
-function parseAdoptionLevelInformation(adoptionLevelInformation) {
-  const keyMetrics = adoptionLevelInformation.metrics.filter(
+function parseConfigurationLevelInformation(configurationLevelInformation) {
+  const keyMetrics = configurationLevelInformation.breakdown.filter(
     (metric) => metric.isFocusMetric,
   );
-  const generalGuidance = adoptionLevelInformation.metrics.filter(
+  const generalGuidance = configurationLevelInformation.breakdown.filter(
     (metric) => !metric.isFocusMetric,
   );
   return [keyMetrics, generalGuidance];
@@ -17,16 +22,28 @@ function parseAdoptionLevelInformation(adoptionLevelInformation) {
 
 function MetricRow({ description, suggestion, level }) {
   var showSuggestion = true;
-  var statusIcon = <Help className={styles.levelIndicatorIcon}/>;
-  switch (level) {
+  var statusIcon = <Help className={styles.levelIndicatorIcon} />;
+  switch (level.toUpperCase()) {
     case "NONE":
-      statusIcon = <StatusAlert className={`${styles.levelIndicatorIcon} ${styles.noAdoption}`}/>;
+      statusIcon = (
+        <StatusAlert
+          className={`${styles.levelIndicatorIcon} ${styles.noAdoption}`}
+        />
+      );
       break;
     case "PARTIAL":
-      statusIcon = <Information className={`${styles.levelIndicatorIcon} ${styles.partialAdoption}`}/>;
+      statusIcon = (
+        <Information
+          className={`${styles.levelIndicatorIcon} ${styles.partialAdoption}`}
+        />
+      );
       break;
     case "COMPLETE":
-      statusIcon = <StatusSuccess className={`${styles.levelIndicatorIcon} ${styles.completeAdoption}`}/>;
+      statusIcon = (
+        <StatusSuccess
+          className={`${styles.levelIndicatorIcon} ${styles.completeAdoption}`}
+        />
+      );
       showSuggestion = false;
       break;
     default:
@@ -35,9 +52,7 @@ function MetricRow({ description, suggestion, level }) {
 
   return (
     <div className={styles.metricRow}>
-      <div className={styles.levelIndicator}>
-        {statusIcon}
-      </div>
+      <div className={styles.levelIndicator}>{statusIcon}</div>
       <div className={styles.metricRowTextWrapper}>
         <div>
           <div className={styles.metricRowText}>{description}</div>
@@ -55,48 +70,52 @@ function MetricRow({ description, suggestion, level }) {
 }
 
 export function CapabilityAdoptionLevel() {
-  // does set update the backend? How is this done in the metadata view?
-  const { adoptionLevelInformation } = useContext(SelectedCapabilityContext);
-
   const [keyMetrics, setKeyMetrics] = useState([]);
   const [generalGuidance, setGeneralGuidance] = useState([]);
+  const { configurationLevelInformation } = useContext(
+    SelectedCapabilityContext,
+  );
 
   useEffect(() => {
-    if (adoptionLevelInformation) {
-      const [keyMetrics, generalGuidance] = parseAdoptionLevelInformation(
-        adoptionLevelInformation,
+    if (configurationLevelInformation) {
+      const [keyMetrics, generalGuidance] = parseConfigurationLevelInformation(
+        configurationLevelInformation,
       );
       setKeyMetrics(keyMetrics);
       setGeneralGuidance(generalGuidance);
     }
-  }, [adoptionLevelInformation]);
+  }, [configurationLevelInformation]);
 
   return (
     <>
-      <PageSection headline="Adoption Level">
-        <div className={styles.columnWrapper}>
-          <div className={styles.column}>
-            <Text styledAs={"smallHeadline"}>Key Metrics</Text>
-            {(keyMetrics || []).map((metric) => (
-              <MetricRow
-                description={metric.description}
-                suggestion={metric.suggestion}
-                level={metric.level}
-              ></MetricRow>
-            ))}
+      {configurationLevelInformation && (
+        <PageSection headline="Adoption Level">
+          <div className={styles.columnWrapper}>
+            <div className={styles.column}>
+              <Text styledAs={"smallHeadline"}>Key Metrics</Text>
+              {(keyMetrics || []).map((metric) => (
+                <MetricRow
+                  key={metric.identifier}
+                  description={metric.description}
+                  suggestion={metric.suggestion}
+                  level={metric.level}
+                ></MetricRow>
+              ))}
+            </div>
+            <div className={styles.column}>
+              <Text styledAs={"smallHeadline"}>General Guidance</Text>
+              {(generalGuidance || []).map((metric) => (
+                <MetricRow
+                  key={metric.identifier}
+                  description={metric.description}
+                  suggestion={metric.suggestion}
+                  level={metric.level}
+                ></MetricRow>
+              ))}
+            </div>
           </div>
-          <div className={styles.column}>
-            <Text styledAs={"smallHeadline"}>General Guidance</Text>
-            {(generalGuidance || []).map((metric) => (
-              <MetricRow
-                description={metric.description}
-                suggestion={metric.suggestion}
-                level={metric.level}
-              ></MetricRow>
-            ))}
-          </div>
-        </div>
-      </PageSection>
+        </PageSection>
+      )}
     </>
   );
 }

--- a/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
+++ b/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
@@ -20,25 +20,31 @@ function parseConfigurationLevelInformation(configurationLevelInformation) {
   return [keyMetrics, generalGuidance];
 }
 
+const ConfigurationLevel = {
+  NONE: "NONE",
+  PARTIAL: "PARTIAL",
+  COMPLETE: "COMPLETE",
+};
+
 function MetricRow({ description, suggestion, level }) {
   var showSuggestion = true;
   var statusIcon = <Help className={styles.levelIndicatorIcon} />;
   switch (level.toUpperCase()) {
-    case "NONE":
+    case ConfigurationLevel.NONE:
       statusIcon = (
         <StatusAlert
           className={`${styles.levelIndicatorIcon} ${styles.noAdoption}`}
         />
       );
       break;
-    case "PARTIAL":
+    case ConfigurationLevel.PARTIAL:
       statusIcon = (
         <Information
           className={`${styles.levelIndicatorIcon} ${styles.partialAdoption}`}
         />
       );
       break;
-    case "COMPLETE":
+    case ConfigurationLevel.COMPLETE:
       statusIcon = (
         <StatusSuccess
           className={`${styles.levelIndicatorIcon} ${styles.completeAdoption}`}

--- a/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
+++ b/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
@@ -3,6 +3,7 @@ import PageSection from "../../../components/PageSection";
 import SelectedCapabilityContext from "../SelectedCapabilityContext";
 import styles from "./capabilityAdoptionLevel.module.css";
 import { Text } from "@dfds-ui/typography";
+import { StatusSuccess, StatusAlert, Information, Help } from "@dfds-ui/icons/system";
 
 function parseAdoptionLevelInformation(adoptionLevelInformation) {
   const keyMetrics = adoptionLevelInformation.metrics.filter(
@@ -16,16 +17,16 @@ function parseAdoptionLevelInformation(adoptionLevelInformation) {
 
 function MetricRow({ description, suggestion, level }) {
   var showSuggestion = true;
-  var statusColor = "unknown";
+  var statusIcon = <Help className={styles.levelIndicatorIcon}/>;
   switch (level) {
     case "NONE":
-      statusColor = "none";
+      statusIcon = <StatusAlert className={`${styles.levelIndicatorIcon} ${styles.noAdoption}`}/>;
       break;
     case "PARTIAL":
-      statusColor = "partial";
+      statusIcon = <Information className={`${styles.levelIndicatorIcon} ${styles.partialAdoption}`}/>;
       break;
     case "COMPLETE":
-      statusColor = "complete";
+      statusIcon = <StatusSuccess className={`${styles.levelIndicatorIcon} ${styles.completeAdoption}`}/>;
       showSuggestion = false;
       break;
     default:
@@ -34,7 +35,9 @@ function MetricRow({ description, suggestion, level }) {
 
   return (
     <div className={styles.metricRow}>
-      <div className={`${styles.levelIndicator} ${styles[statusColor]}`} />
+      <div className={styles.levelIndicator}>
+        {statusIcon}
+      </div>
       <div className={styles.metricRowTextWrapper}>
         <div>
           <div className={styles.metricRowText}>{description}</div>
@@ -42,7 +45,7 @@ function MetricRow({ description, suggestion, level }) {
             <div
               className={`${styles.metricRowText} ${styles.metricRowSuggestion}`}
             >
-              {suggestion}
+              Suggestion: {suggestion}
             </div>
           )}
         </div>
@@ -67,10 +70,6 @@ export function CapabilityAdoptionLevel() {
       setGeneralGuidance(generalGuidance);
     }
   }, [adoptionLevelInformation]);
-
-  useEffect(() => {
-    console.log(generalGuidance);
-  }, [generalGuidance]);
 
   return (
     <>

--- a/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
+++ b/src/src/pages/capabilities/capabilityAdoptionLevel/index.js
@@ -1,0 +1,103 @@
+import React, { useEffect, useContext, useState } from "react";
+import PageSection from "../../../components/PageSection";
+import SelectedCapabilityContext from "../SelectedCapabilityContext";
+import styles from "./capabilityAdoptionLevel.module.css";
+import { Text } from "@dfds-ui/typography";
+
+function parseAdoptionLevelInformation(adoptionLevelInformation) {
+  const keyMetrics = adoptionLevelInformation.metrics.filter(
+    (metric) => metric.isFocusMetric,
+  );
+  const generalGuidance = adoptionLevelInformation.metrics.filter(
+    (metric) => !metric.isFocusMetric,
+  );
+  return [keyMetrics, generalGuidance];
+}
+
+function MetricRow({ description, suggestion, level }) {
+  var showSuggestion = true;
+  var statusColor = "unknown";
+  switch (level) {
+    case "NONE":
+      statusColor = "none";
+      break;
+    case "PARTIAL":
+      statusColor = "partial";
+      break;
+    case "COMPLETE":
+      statusColor = "complete";
+      showSuggestion = false;
+      break;
+    default:
+      break;
+  }
+
+  return (
+    <div className={styles.metricRow}>
+      <div className={`${styles.levelIndicator} ${styles[statusColor]}`} />
+      <div className={styles.metricRowTextWrapper}>
+        <div>
+          <div className={styles.metricRowText}>{description}</div>
+          {showSuggestion && (
+            <div
+              className={`${styles.metricRowText} ${styles.metricRowSuggestion}`}
+            >
+              {suggestion}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CapabilityAdoptionLevel() {
+  // does set update the backend? How is this done in the metadata view?
+  const { adoptionLevelInformation } = useContext(SelectedCapabilityContext);
+
+  const [keyMetrics, setKeyMetrics] = useState([]);
+  const [generalGuidance, setGeneralGuidance] = useState([]);
+
+  useEffect(() => {
+    if (adoptionLevelInformation) {
+      const [keyMetrics, generalGuidance] = parseAdoptionLevelInformation(
+        adoptionLevelInformation,
+      );
+      setKeyMetrics(keyMetrics);
+      setGeneralGuidance(generalGuidance);
+    }
+  }, [adoptionLevelInformation]);
+
+  useEffect(() => {
+    console.log(generalGuidance);
+  }, [generalGuidance]);
+
+  return (
+    <>
+      <PageSection headline="Adoption Level">
+        <div className={styles.columnWrapper}>
+          <div className={styles.column}>
+            <Text styledAs={"smallHeadline"}>Key Metrics</Text>
+            {(keyMetrics || []).map((metric) => (
+              <MetricRow
+                description={metric.description}
+                suggestion={metric.suggestion}
+                level={metric.level}
+              ></MetricRow>
+            ))}
+          </div>
+          <div className={styles.column}>
+            <Text styledAs={"smallHeadline"}>General Guidance</Text>
+            {(generalGuidance || []).map((metric) => (
+              <MetricRow
+                description={metric.description}
+                suggestion={metric.suggestion}
+                level={metric.level}
+              ></MetricRow>
+            ))}
+          </div>
+        </div>
+      </PageSection>
+    </>
+  );
+}

--- a/src/src/pages/capabilities/details.js
+++ b/src/src/pages/capabilities/details.js
@@ -47,6 +47,7 @@ function CapabilityDetailsPageContent() {
     isInviteesCreated,
     members,
     metadata,
+    adoptionLevelInformation,
   } = useContext(SelectedCapabilityContext);
 
   useEffect(() => {
@@ -92,7 +93,9 @@ function CapabilityDetailsPageContent() {
         <Members />
         <Summary />
 
-        <CapabilityAdoptionLevel />
+        <CapabilityAdoptionLevel
+          adoptionLevelInformation={adoptionLevelInformation}
+        />
 
         <CapabilityTagViewer />
 

--- a/src/src/pages/capabilities/details.js
+++ b/src/src/pages/capabilities/details.js
@@ -14,6 +14,7 @@ import CapabilityManagement from "./capabilityManagement";
 import { CapabilityInvitations } from "./capabilityInvitations/capabilityInvitations";
 import { JsonMetadataWithSchemaViewer } from "./jsonmetadata";
 import { CapabilityTagViewer } from "./capabilityTags";
+import { CapabilityAdoptionLevel } from "./capabilityAdoptionLevel";
 import { JsonSchemaProvider } from "../../JsonSchemaContext";
 
 export default function CapabilityDetailsPage() {
@@ -90,6 +91,8 @@ function CapabilityDetailsPageContent() {
       <Page title={pagetitle} isLoading={isLoading} isNotFound={!isFound}>
         <Members />
         <Summary />
+
+        <CapabilityAdoptionLevel />
 
         <CapabilityTagViewer />
 

--- a/src/src/pages/capabilities/summary/index.js
+++ b/src/src/pages/capabilities/summary/index.js
@@ -201,7 +201,9 @@ export default function Summary() {
           <Text styledAs={"smallHeadline"}>Root Id</Text>{" "}
           <span className={styles.breakwords}>{id}</span>
         </div>
-        <div className={styles.column}>
+      </div>
+      <div className={styles.container}>
+        <div className={styles.doubleColumn}>
           <Text styledAs={"smallHeadline"}>Description</Text>{" "}
           <span className={styles.breakwords}>{description}</span>
         </div>

--- a/src/src/pages/capabilities/summary/summary.module.css
+++ b/src/src/pages/capabilities/summary/summary.module.css
@@ -6,6 +6,10 @@
   width: 33%;
 }
 
+.doubleColumn {
+  width: 66%;
+}
+
 .breakwords {
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2526

# Additional Review Notes
We need a better suggestion for how to indicate 'good', 'bad', 'neutral'.

JanV is not a fan of integer-scores, and quite focused on this ternary system.
Further more, he is 100% against showing an overall capability score, so I removed that for now.

But how do we improve the inherent understanding of what is needed.

![Screenshot 2024-01-25 152403](https://github.com/dfds/selfservice-portal/assets/177252/17a26c6f-6ccd-4a3b-b33f-abab2ea00fa9)


# Update!
![image](https://github.com/dfds/selfservice-portal/assets/177252/5abe3c8c-01c7-4f6c-a2ed-65749aabe88d)

Less powerful, but follows DFDS iconography, is less in your face, and is better for colour blindness 🤷‍♂️ 