### PR TITLE
Live life dangerously

### DIFF
--- a/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
@@ -14,7 +14,6 @@ import Form from "@rjsf/core";
 import validator from "@rjsf/validator-ajv8";
 import Select from "react-select";
 import JsonSchemaContext from "../../../JsonSchemaContext";
-import DOMPurify from "dompurify";
 
 /*
  * Custom Widgets and Fields
@@ -32,7 +31,7 @@ function CustomFieldTemplate(props) {
       {rawDescription ? (
         <span
           dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(rawDescription),
+            __html: rawDescription,
           }}
         />
       ) : null}


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2544

# Additional Review Notes
Sanitizing HTML removes `target='_blank'` as it is considered dangerous, granting access to the window.

I do not like this. However, the original argument still stands; We are (kind of, sort of, maybe) in control of the input and therefore we can accept this thing.

However, I believe we should figure out if all these hoops are worth keeping, simply in order to use the JsonSchemaForReact library.