### PR TITLE
Criticality subpage for Cloud Engineers

### DIFF
--- a/src/src/App.js
+++ b/src/src/App.js
@@ -7,8 +7,8 @@ import FrontPage from "./pages/frontpage";
 import TopicsPage from "./pages/topics";
 import CapabilitiesPage from "./pages/capabilities";
 import CapabilityDetailsPage from "./pages/capabilities/details";
+import CapabilityCriticalityPage from "./pages/capabilities/criticality";
 import ECRPage from "./pages/ecr";
-
 import { AuthenticatedTemplate } from "@azure/msal-react";
 
 function Footer() {
@@ -50,6 +50,10 @@ export default function App() {
           <Route path="topics" element={<TopicsPage />} />
           <Route path="capabilities" element={<CapabilitiesPage />} />
           <Route path="ecr" element={<ECRPage />} />
+          <Route
+            path="capabilities/criticality"
+            element={<CapabilityCriticalityPage />}
+          />
           <Route path="capabilities/:id" element={<CapabilityDetailsPage />} />
         </Route>
       </Routes>

--- a/src/src/components/GlobalMenu/GlobalMenu.jsx
+++ b/src/src/components/GlobalMenu/GlobalMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   AppBar as DFDSAppBar,
@@ -15,8 +15,21 @@ import { SmallProfilePicture as ProfilePicture } from "components/ProfilePicture
 import AppContext from "AppContext";
 import styles from "./GlobalMenu.module.css";
 
+function checkIfCloudEngineer(title) {
+  const regex = /^\s*cloud[-_\.\s]engineer\s*$/g;
+  const match = title?.toLowerCase().match(regex);
+  return match && match.length > 0;
+}
+
 export default function GlobalMenu() {
   const { user } = useContext(AppContext);
+
+  const [isCloudEngineer, setIsCloudEngineer] = useState(false);
+  useEffect(() => {
+    if (user && user.isAuthenticated) {
+      setIsCloudEngineer(checkIfCloudEngineer(user.title));
+    }
+  }, [user]);
 
   const navLinks = [
     {
@@ -44,6 +57,13 @@ export default function GlobalMenu() {
       url: "https://dfdsit.statuspage.io/",
     },
   ];
+
+  if (isCloudEngineer) {
+    navLinks.push({
+      title: "Criticality",
+      url: "/capabilities/criticality",
+    });
+  }
 
   return (
     <>

--- a/src/src/pages/capabilities/OtherCapabilities.js
+++ b/src/src/pages/capabilities/OtherCapabilities.js
@@ -189,18 +189,6 @@ export default function OtherCapabilities() {
               enableTopToolbar={true}
               enableBottomToolbar={true}
               enableColumnActions={false}
-              muiTableBodyRowProps2={({ row }) => ({
-                onClick: () => {
-                  clickHandler(row.original.id);
-                },
-                sx: {
-                  cursor: "pointer",
-                  background: row.original.status === "Delete" ? "#d88" : "",
-                  padding: 0,
-                  margin: 0,
-                  minHeight: 0,
-                },
-              })}
               muiTopToolbarProps={{
                 sx: {
                   background: "none",

--- a/src/src/pages/capabilities/criticality.js
+++ b/src/src/pages/capabilities/criticality.js
@@ -1,0 +1,312 @@
+import React, { useContext, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import Page from "components/Page";
+import { useCapabilities } from "hooks/Capabilities";
+import AppContext from "AppContext";
+import { Text } from "@dfds-ui/typography";
+import {
+  Card,
+  CardTitle,
+  CardContent,
+  Spinner,
+} from "@dfds-ui/react-components";
+import { MaterialReactTable } from "material-react-table";
+import PageSection from "components/PageSection";
+
+function calculateCriticalityLevel(
+  availability,
+  criticality,
+  classification,
+  status,
+) {
+  if (status === "Deleted") {
+    return 1;
+  }
+
+  if (
+    availability === undefined &&
+    criticality === undefined &&
+    classification === undefined
+  ) {
+    return 5;
+  }
+  if (
+    availability === undefined ||
+    criticality === undefined ||
+    classification === undefined
+  ) {
+    return 4;
+  }
+  if (
+    availability === "High" ||
+    criticality === "High" ||
+    classification !== "Public"
+  ) {
+    return 3;
+  }
+  if (
+    availability === "Medium" ||
+    criticality === "Medium" ||
+    classification !== "Public"
+  ) {
+    return 2;
+  }
+  return 1;
+}
+
+export default function CapabilitiesCriticalityPage() {
+  const { capabilities, isLoaded } = useCapabilities();
+  const { truncateString } = useContext(AppContext);
+
+  const navigate = useNavigate();
+  const clickHandler = (id) => navigate(`/capabilities/${id}`);
+
+  const columns = useMemo(
+    () => [
+      {
+        accessorFn: (row) => row.name,
+        header: "Name",
+        size: 350,
+        enableColumnFilterModes: true,
+        disableFilters: false,
+        enableGlobalFilter: true,
+        enableFilterMatchHighlighting: true,
+
+        Cell: ({ cell, renderedCellValue }) => {
+          return (
+            <div>
+              {" "}
+              <Text styledAs="action" as={"div"}>
+                {truncateString(renderedCellValue)}
+              </Text>
+            </div>
+          );
+        },
+      },
+      {
+        accessorFn: (row) => row,
+        header: "Score",
+        size: 25,
+        enableColumnFilterModes: false,
+        muiTableHeadCellProps: {
+          align: "center",
+        },
+        muiTableBodyCellProps: {
+          align: "center",
+        },
+        Cell: ({ cell }) => {
+          const jsonMetadata = JSON.parse(cell.getValue().jsonMetadata ?? "{}");
+          const status = cell.getValue().status;
+          return (
+            <Text>
+              {calculateCriticalityLevel(
+                jsonMetadata["dfds.service.availability"],
+                jsonMetadata["dfds.service.criticality"],
+                jsonMetadata["dfds.data.classification"],
+                status,
+              )}
+            </Text>
+          );
+        },
+      },
+      {
+        accessorFn: (row) => row.jsonMetadata,
+        header: "Criticality",
+        size: 25,
+        enableColumnFilterModes: false,
+        muiTableHeadCellProps: {
+          align: "center",
+        },
+        muiTableBodyCellProps: {
+          align: "center",
+        },
+        Cell: ({ cell }) => {
+          const jsonMetadata = JSON.parse(cell.getValue() ?? "{}");
+          if (jsonMetadata["dfds.service.criticality"] === undefined) {
+            return <div>unknown</div>;
+          }
+          return <div>{jsonMetadata["dfds.service.criticality"]}</div>;
+        },
+      },
+      {
+        accessorFn: (row) => row.jsonMetadata,
+        header: "Availability",
+        size: 25,
+        enableColumnFilterModes: false,
+        muiTableHeadCellProps: {
+          align: "center",
+        },
+        muiTableBodyCellProps: {
+          align: "center",
+        },
+        Cell: ({ cell }) => {
+          const jsonMetadata = JSON.parse(cell.getValue() ?? "{}");
+          if (jsonMetadata["dfds.service.availability"] === undefined) {
+            return <div>unknown</div>;
+          }
+          return <div>{jsonMetadata["dfds.service.availability"]}</div>;
+        },
+      },
+      {
+        accessorFn: (row) => row.jsonMetadata,
+        header: "Classification",
+        size: 25,
+        enableColumnFilterModes: false,
+        muiTableHeadCellProps: {
+          align: "center",
+        },
+        muiTableBodyCellProps: {
+          align: "center",
+        },
+        Cell: ({ cell }) => {
+          const jsonMetadata = JSON.parse(cell.getValue() ?? "{}");
+          if (jsonMetadata["dfds.data.classification"] === undefined) {
+            return <div>unknown</div>;
+          }
+          return <div>{jsonMetadata["dfds.data.classification"]}</div>;
+        },
+      },
+      {
+        accessorFn: (row) => row.status,
+        header: "Deleted",
+        size: 25,
+        enableColumnFilterModes: false,
+        muiTableHeadCellProps: {
+          align: "center",
+        },
+        muiTableBodyCellProps: {
+          align: "center",
+        },
+        Cell: ({ cell }) => {
+          if (cell.getValue() === "Deleted") {
+            return <div>Deleted</div>;
+          }
+          return <div></div>;
+        },
+      },
+    ],
+    [],
+  );
+
+  return (
+    <>
+      <Page title="Capability Criticality">
+        <Card variant="fill" surface="main" size="xl" reverse={true}>
+          <CardTitle largeTitle>Information</CardTitle>
+          <CardContent>
+            <p>
+              Criticality is derived from the tags applied to the capability.
+              The table below show the individual tags as well as an overall
+              score. The overall score is a loose criticality approximation
+              based on the following:
+            </p>
+            <ul>
+              <li>5: None of the expected tags are set for the capability.</li>
+              <li>
+                4: At least one of the expected tags is not set for the
+                capability.
+              </li>
+              <li>
+                3: All expected tags set. At least one of the expected tags is
+                set to High for the capability or classification is not Public
+              </li>
+              <li>
+                2: All expected tags set. At least one of the expected tags is
+                set to Medium for the capability or classification is not Public
+              </li>
+              <li>
+                1: All expected tags are set to Low for the capability and
+                classification is Public
+              </li>
+            </ul>
+            <p>
+              Note: Deleted capabilities are automatically granted a score of 1.
+            </p>
+          </CardContent>
+        </Card>
+
+        <PageSection headline="Criticality">
+          {!isLoaded && <Spinner />}
+
+          {isLoaded && (
+            <MaterialReactTable
+              columns={columns}
+              data={capabilities}
+              initialState={{
+                pagination: { pageSize: 50 },
+                showGlobalFilter: true,
+              }}
+              muiTableHeadCellProps={{
+                sx: {
+                  fontWeight: "700",
+                  fontSize: "16px",
+                  fontFamily: "DFDS",
+                  color: "#002b45",
+                },
+              }}
+              muiTableBodyCellProps={{
+                sx: {
+                  fontWeight: "400",
+                  fontSize: "16px",
+                  fontFamily: "DFDS",
+                  color: "#4d4e4c",
+                  padding: "5px",
+                },
+              }}
+              muiTableBodyRowProps={({ row }) => {
+                return {
+                  onClick: () => {
+                    clickHandler(row.original.id);
+                  },
+                  sx: {
+                    cursor: "pointer",
+                    background: row.original.status === "Deleted" ? "#d88" : "",
+                    padding: 0,
+                    margin: 0,
+                    minHeight: 0,
+                    "&:hover td": {
+                      backgroundColor:
+                        row.original.status === "Deleted"
+                          ? "rgba(187, 221, 243, 0.1)"
+                          : "rgba(187, 221, 243, 0.4)",
+                    },
+                  },
+                };
+              }}
+              muiTablePaperProps={{
+                elevation: 0,
+                sx: {
+                  borderRadius: "0",
+                },
+              }}
+              enableGlobalFilterModes={true}
+              positionGlobalFilter="left"
+              muiSearchTextFieldProps={{
+                placeholder: `Find a capability...`,
+                sx: {
+                  minWidth: "1120px",
+                  fontWeight: "400",
+                  fontSize: "16px",
+                  padding: "5px",
+                },
+                size: "small",
+                variant: "outlined",
+              }}
+              enablePagination={true}
+              globalFilterFn="contains"
+              enableFilterMatchHighlighting={true}
+              enableDensityToggle={true}
+              enableFullScreenToggle={true}
+              enableHiding={true}
+              enableFilters={true}
+              enableGlobalFilter={true}
+              enableTopToolbar={true}
+              enableBottomToolbar={true}
+              enableColumnActions={true}
+            />
+          )}
+        </PageSection>
+      </Page>
+    </>
+  );
+}


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2597

# Additional Review Notes
Separate page for seeing capability criticality based on tagging.
Only visible to Cloud Engineers.

Also added a flag in AppContext for checking Cloud Engineering status of the logged in user.
I have missed this a few times.


![image](https://github.com/dfds/selfservice-portal/assets/177252/051b7040-adab-4e7d-bc5f-52eb0d55e668)

