### PR TITLE
improved ux of the NewCapabilityDialog

### DIFF
--- a/src/src/AppContext.js
+++ b/src/src/AppContext.js
@@ -16,6 +16,16 @@ function sleep(duration) {
   });
 }
 
+function isAllWithValues(data) {
+  let result = true;
+  data.forEach((x) => {
+    if (x === undefined || x == null || x === "") {
+      result = false;
+    }
+  });
+  return result;
+}
+
 function truncateString(str) {
   const maxLength = 70;
   if (str.length > maxLength) {
@@ -170,6 +180,7 @@ function AppProvider({ children }) {
     reload,
     repositories,
     isLoading,
+    isAllWithValues,
   };
 
   return <AppContext.Provider value={state}>{children}</AppContext.Provider>;

--- a/src/src/pages/capabilities/NewCapabilityDialog.js
+++ b/src/src/pages/capabilities/NewCapabilityDialog.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, createRef, useEffect } from "react";
+import React, { useState, useContext, createRef } from "react";
 import { Button, ButtonStack } from "@dfds-ui/react-components";
 import { SideSheet, SideSheetContent } from "@dfds-ui/react-components";
 import { Tooltip, TextField } from "@dfds-ui/react-components";
@@ -7,7 +7,6 @@ import { Invitations } from "./invitations";
 import { CapabilityTagsSubForm } from "./capabilityTags/capabilityTagsSubForm";
 import { JsonSchemaProvider } from "../../JsonSchemaContext";
 import AppContext from "../../AppContext";
-import { isValid } from "date-fns";
 
 export default function NewCapabilityDialog({
   inProgress,

--- a/src/src/pages/capabilities/capabilityTags/capabilityTags.module.css
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTags.module.css
@@ -37,7 +37,3 @@
   color: #be1e2d;
   margin-top: 3px;
 }
-
-
-
-

--- a/src/src/pages/capabilities/capabilityTags/capabilityTags.module.css
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTags.module.css
@@ -26,3 +26,18 @@
   margin-right: 0.25rem;
   margin-left: 1rem;
 }
+
+.fieldError > div {
+  border: 2px solid #be1e2d;
+}
+
+.errorMessage {
+  font-size: 12px;
+  line-height: 15px;
+  color: #be1e2d;
+  margin-top: 3px;
+}
+
+
+
+

--- a/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
@@ -20,18 +20,17 @@ import JsonSchemaContext from "../../../JsonSchemaContext";
  */
 
 function CustomFieldTemplate(props) {
-  
-  const { id, label, required, rawDescription, children, errors, rawErrors } = props;
+  const { id, label, required, rawDescription, children, errors, rawErrors } =
+    props;
   const [classNames, setClassNames] = useState(styles.field);
   useEffect(() => {
     if (rawErrors) {
       setClassNames(`${styles.field}`);
-    }else {
+    } else {
       setClassNames(`${styles.field}`);
     }
-  }, [rawErrors])
-  
-  
+  }, [rawErrors]);
+
   // Further fields 'errors' and 'help' might come in handy later
   // https://react-jsonschema-form.readthedocs.io/en/v1.8.1/advanced-customization/
   return (
@@ -46,7 +45,9 @@ function CustomFieldTemplate(props) {
           }}
         />
       ) : null}
-      <div className={rawErrors ? styles.fieldError : null} key={id}>{children}</div>
+      <div className={rawErrors ? styles.fieldError : null} key={id}>
+        {children}
+      </div>
       <div className={styles.errorMessage}>{rawErrors}</div>
     </div>
   );
@@ -162,8 +163,7 @@ export function CapabilityTagsSubForm({
 
   const errorHandler = (parameters) => {
     console.log(parameters);
-  }
-
+  };
 
   return (
     <>
@@ -188,9 +188,9 @@ export function CapabilityTagsSubForm({
             templates={{ FieldTemplate: CustomFieldTemplate }}
             formData={preexistingFormData}
             children={true} // hide submit button
-            ref = {formRef}
-            showErrorList = {false}
-            onError = {errorHandler}
+            ref={formRef}
+            showErrorList={false}
+            onError={errorHandler}
           />
         </>
       )}

--- a/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
@@ -20,7 +20,7 @@ import JsonSchemaContext from "../../../JsonSchemaContext";
  */
 
 function CustomFieldTemplate(props) {
-  const { id, label, required, rawDescription, children, errors, rawErrors } =
+  const { id, label, required, rawDescription, children, rawErrors } =
     props;
   const [classNames, setClassNames] = useState(styles.field);
   useEffect(() => {
@@ -54,7 +54,7 @@ function CustomFieldTemplate(props) {
 }
 
 const CustomDropdown = function (props) {
-  const { options, value, onChange, id, rawErrors } = props;
+  const { options, value, onChange, id } = props;
   // remove 'root_' prefix and replace '.' with '-' to have a valid css id
   var cleanId = id.replace(/^[a-zA-Z0-9]*_/, "").replace(/\./g, "-");
   return (

--- a/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
@@ -20,11 +20,22 @@ import JsonSchemaContext from "../../../JsonSchemaContext";
  */
 
 function CustomFieldTemplate(props) {
-  const { id, label, required, rawDescription, children } = props;
+  
+  const { id, label, required, rawDescription, children, errors, rawErrors } = props;
+  const [classNames, setClassNames] = useState(styles.field);
+  useEffect(() => {
+    if (rawErrors) {
+      setClassNames(`${styles.field}`);
+    }else {
+      setClassNames(`${styles.field}`);
+    }
+  }, [rawErrors])
+  
+  
   // Further fields 'errors' and 'help' might come in handy later
   // https://react-jsonschema-form.readthedocs.io/en/v1.8.1/advanced-customization/
   return (
-    <div className={styles.field}>
+    <div className={classNames}>
       {required ? <span className={styles.bold}>*</span> : null}
       <label htmlFor={id}>{label}</label>
       <br />
@@ -35,14 +46,14 @@ function CustomFieldTemplate(props) {
           }}
         />
       ) : null}
-      {children}
+      <div className={rawErrors ? styles.fieldError : null} key={id}>{children}</div>
+      <div className={styles.errorMessage}>{rawErrors}</div>
     </div>
   );
 }
 
 const CustomDropdown = function (props) {
-  const { options, value, onChange, id } = props;
-
+  const { options, value, onChange, id, rawErrors } = props;
   // remove 'root_' prefix and replace '.' with '-' to have a valid css id
   var cleanId = id.replace(/^[a-zA-Z0-9]*_/, "").replace(/\./g, "-");
   return (
@@ -113,6 +124,7 @@ export function CapabilityTagsSubForm({
   setMetadata,
   setValidMetadata,
   preexistingFormData,
+  formRef,
 }) {
   const { jsonSchema, jsonSchemaString, hasJsonSchemaProperties } =
     useContext(JsonSchemaContext);
@@ -148,6 +160,11 @@ export function CapabilityTagsSubForm({
     CheckboxWidget: CustomCheckbox,
   };
 
+  const errorHandler = (parameters) => {
+    console.log(parameters);
+  }
+
+
   return (
     <>
       {showTagForm && (
@@ -171,6 +188,9 @@ export function CapabilityTagsSubForm({
             templates={{ FieldTemplate: CustomFieldTemplate }}
             formData={preexistingFormData}
             children={true} // hide submit button
+            ref = {formRef}
+            showErrorList = {false}
+            onError = {errorHandler}
           />
         </>
       )}

--- a/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
+++ b/src/src/pages/capabilities/capabilityTags/capabilityTagsSubForm.js
@@ -20,8 +20,7 @@ import JsonSchemaContext from "../../../JsonSchemaContext";
  */
 
 function CustomFieldTemplate(props) {
-  const { id, label, required, rawDescription, children, rawErrors } =
-    props;
+  const { id, label, required, rawDescription, children, rawErrors } = props;
   const [classNames, setClassNames] = useState(styles.field);
   useEffect(() => {
     if (rawErrors) {


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2585

# Additional Review Notes

Improving the UX of this form turned out to be quiet complicated due to the third party library we use for the JasonSchema. @SEQUOIIA and I did some work around in order to visualise the error if the cost centre is not filled out. This is not the ideal solution but it was the best we could do for now. I am looking forward for suggestions how to improve it. 

<img width="453" alt="image" src="https://github.com/dfds/selfservice-portal/assets/58768740/9c771741-4b7a-4d78-ad10-5678dba3f9d1">

