### PR TITLE
Message type doesn't allow uppercase

### DIFF
--- a/src/src/pages/capabilities/KafkaCluster/MessageContractDialog.js
+++ b/src/src/pages/capabilities/KafkaCluster/MessageContractDialog.js
@@ -238,7 +238,7 @@ export default function MessageContractDialog({
     e?.preventDefault();
     let newTopic = e?.target?.value || "";
     newTopic = newTopic.replace(/\s+/g, "-");
-    setMessageType(newTopic);
+    setMessageType(newTopic.toLowerCase());
   };
 
   const changeDescription = (e) => {


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2634

# Additional Review Notes

Message Type doesn't allow you to use uppercase

<img width="781" alt="image" src="https://github.com/dfds/selfservice-portal/assets/58768740/a18169c2-203b-46a8-a201-acb8bd7bd3fa">

