### PR TITLE
Discussion: Add Capabilities using a Wizard

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -34,6 +34,7 @@
         "react-select": "5.7.0",
         "react-syntax-highlighter": "^15.5.0",
         "react-tooltip": "^5.21.1",
+        "react-use-wizard": "^2.3.0",
         "recharts": "^2.7.2",
         "serve": "^14.1.2",
         "to-json-schema": "^0.2.5"
@@ -17504,6 +17505,18 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-use-wizard": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-use-wizard/-/react-use-wizard-2.3.0.tgz",
+      "integrity": "sha512-z06pQNZ18FvoK+ZDW50hOf0uOySo0Hhd7H4y0MLyk/tBCwpUKGBeULosORBVhipUaWihNLpLJxwH5f+85Qt5XA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-with-styles": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-4.2.0.tgz",
@@ -33613,6 +33626,12 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-use-wizard": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-use-wizard/-/react-use-wizard-2.3.0.tgz",
+      "integrity": "sha512-z06pQNZ18FvoK+ZDW50hOf0uOySo0Hhd7H4y0MLyk/tBCwpUKGBeULosORBVhipUaWihNLpLJxwH5f+85Qt5XA==",
+      "requires": {}
     },
     "react-with-styles": {
       "version": "4.2.0",

--- a/src/package.json
+++ b/src/package.json
@@ -33,6 +33,7 @@
     "react-select": "5.7.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-tooltip": "^5.21.1",
+    "react-use-wizard": "^2.3.0",
     "recharts": "^2.7.2",
     "serve": "^14.1.2",
     "to-json-schema": "^0.2.5"

--- a/src/src/CreationWizard.js
+++ b/src/src/CreationWizard.js
@@ -1,0 +1,185 @@
+import React, { useState, useContext, createRef, useEffect } from "react";
+import { Button } from "@dfds-ui/react-components";
+import { Tooltip, TextField } from "@dfds-ui/react-components";
+import styles from "pages/capabilities/capabilities.module.css";
+import { Wizard, useWizard } from "react-use-wizard";
+import { Modal } from "@dfds-ui/modal";
+import Stepper from "@mui/material/Stepper";
+import Step from "@mui/material/Step";
+import StepLabel from "@mui/material/StepLabel";
+import Check from "@mui/icons-material/Check";
+import Circle from "@mui/icons-material/Circle";
+
+export default function CreationWizard({
+  isOpen,
+  onClose,
+  onComplete,
+  steps,
+  title,
+  sizes = {
+    s: "75%",
+    m: "75%",
+    l: "75%",
+    xl: "75%",
+    xxl: "75%",
+  }
+}) {
+  const emptyFormValues = {
+    name: "",
+    description: "",
+    mandatoryTags: "",
+  };
+
+  const [canContinue, setCanContinue] = useState(true);
+  const [formValues, setFormValues] = useState(emptyFormValues);
+
+
+
+  return (
+    <Modal
+      heading={title}
+      isOpen={isOpen}
+      shouldCloseOnOverlayClick={false}
+      shouldCloseOnEsc={true}
+      showClose={true}
+      fixedTopPosition={true}
+      onRequestClose={onClose}
+      sizes={sizes}
+    >
+      <Wizard
+        startIndex={0}
+        header={<Header steps={steps} />}
+        footer={
+          <Footer
+            onComplete={onComplete}
+            steps={steps}
+            canContinue={canContinue}
+          />
+        }
+      >
+        {steps.map((step) => (
+          <div key={step.title}>
+            {step.content({ formValues, setFormValues, setCanContinue })}
+          </div>
+        ))}
+      </Wizard>
+    </Modal>
+  );
+}
+
+function SelfServiceStepIcon(props) {
+  const { completed, active } = props;
+
+  if (completed) {
+    return <Check className={styles.stepiconcompleted} />;
+  }
+
+  if (active) {
+    return <Circle className={styles.stepiconactive} />;
+  }
+
+  return <Circle className={styles.stepiconunresolved} />;
+}
+
+const Header = ({ steps }) => {
+  const { activeStep } = useWizard();
+
+  return (
+    <Stepper activeStep={activeStep} alternativeLabel>
+      {steps.map((step, index) => {
+        const stepProps = {
+          completed: step.completed && !step.skipped,
+          active: activeStep === index,
+        };
+        return (
+          <Step key={step.title} {...stepProps}>
+            <StepLabel StepIconComponent={SelfServiceStepIcon}>
+              {step.title}{" "}
+              {step.optional && (
+                <>
+                  <br />
+                  <span>(optional)</span>
+                </>
+              )}
+            </StepLabel>
+          </Step>
+        );
+      })}
+    </Stepper>
+  );
+};
+
+const Footer = ({ onComplete, steps, canContinue }) => {
+  const { previousStep, nextStep, activeStep, stepCount } = useWizard();
+
+  return (
+    <div>
+      {activeStep > 0 && (
+        <Button
+          className={styles.backButton}
+          onClick={() => {
+            steps[activeStep - 1].skipped = false;
+            steps[activeStep - 1].completed = false;
+            if (activeStep + 1 === stepCount) {
+              // last step; activeStep is 0-based
+              steps[activeStep].completed = false;
+            }
+            previousStep();
+          }}
+          variation="secondary"
+          size="small"
+        >
+          Back
+        </Button>
+      )}
+      {activeStep + 1 < stepCount && (
+        <Button
+          className={styles.nextButton}
+          disabled={!canContinue}
+          onClick={() => {
+            steps[activeStep].skipped = false;
+            steps[activeStep].completed = true;
+            if (activeStep + 2 === stepCount) {
+              // next step is last step; activeStep is 0-based
+              steps[activeStep + 1].completed = true;
+            }
+            nextStep();
+          }}
+          variation="primary"
+          size="small"
+        >
+          Next
+        </Button>
+      )}
+      {activeStep + 1 < stepCount && steps[activeStep].optional && (
+        <Button
+          className={styles.skipButton}
+          onClick={() => {
+            steps[activeStep].skipped = true;
+            steps[activeStep].completed = true;
+            if (activeStep + 2 === stepCount) {
+              // next step is last step; activeStep is 0-based
+              steps[activeStep + 1].completed = true;
+            }
+            nextStep();
+          }}
+          variation="outlined"
+          size="small"
+        >
+          Skip
+        </Button>
+      )}
+      {activeStep + 1 === stepCount && (
+        <Button
+          className={styles.nextButton}
+          onClick={onComplete}
+          variation="primary"
+          size="small"
+        >
+          Complete
+        </Button>
+      )}
+    </div>
+  );
+};
+

--- a/src/src/pages/capabilities/NewCapabilityWizard.js
+++ b/src/src/pages/capabilities/NewCapabilityWizard.js
@@ -1,0 +1,359 @@
+import React, { useState, useContext, createRef, useEffect } from "react";
+import { Button } from "@dfds-ui/react-components";
+import { Tooltip, TextField } from "@dfds-ui/react-components";
+import styles from "./capabilities.module.css";
+import { Wizard, useWizard } from 'react-use-wizard';
+import { Modal } from "@dfds-ui/modal";
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import Check from '@mui/icons-material/Check';
+import Circle from '@mui/icons-material/Circle';
+
+export default function NewCapabilityWizard({
+  inProgress,
+  onAddCapabilityClicked,
+  onCloseClicked,
+}) {
+    const emptyFormValues = {
+        name: "",
+        description: "",
+        mandatoryTags: "",
+    };
+
+    const [canContinue, setCanContinue] = useState(true);
+    const [formValues, setFormValues] = useState(emptyFormValues)
+
+    let steps = [
+    {
+        title: "Basic Information",
+        content: (props) => <BasicInformationStep {...props} />,
+        optional: false,
+        skipped: false,
+    },
+    {
+        title: "Tags",
+        content: (props) => <MandatoryTagsStep {...props} />,
+        optional: false,
+        skipped: false,
+    },
+    {
+        title: "Additional Tags",
+        content: (props) => <WizardStep {...props} />,
+        optional: true,
+        skipped: false,
+    },
+    {
+        title: "AWS and Azure",
+        content: (props) => <WizardStep {...props} />,
+        optional: true,
+        skipped: false,
+    },
+    {
+        title: "Invitations",
+        content: (props) => <WizardStep {...props} />,
+        optional: true,
+        skipped: false,
+    },
+    {
+        title: "Summary",
+        content: (props) => <WizardStep {...props} />,
+    },
+    ].slice();
+
+  return (
+    <Modal
+        heading={"New Capability Wizard"}
+        isOpen={true}
+        shouldCloseOnOverlayClick={false}
+        shouldCloseOnEsc={true}
+        showClose={true}
+        fixedTopPosition={true}
+        onRequestClose={() => onCloseClicked()}
+        sizes={{
+            s: "75%",
+            m: "75%",
+            l: "75%",
+            xl: "75%",
+            xxl: "75%",
+        }}
+    >
+        <Wizard
+            startIndex={0}
+            header={<Header steps={steps} />}
+            footer={<Footer onAddCapabilityClicked={onAddCapabilityClicked} steps={steps} canContinue={canContinue} />}
+        >
+            {steps.map((step) => (
+                <div key={step.title}>
+                    {step.content({formValues, setFormValues, setCanContinue})}
+                </div>
+            ))}
+        </Wizard>
+    </Modal>
+  );
+}
+
+function SelfServiceStepIcon(props) {
+    const { completed, active } = props;
+
+    if (completed) {
+      return <Check className={styles.stepiconcompleted} />;
+    }
+
+    if (active) {
+      return <Circle className={styles.stepiconactive} />;
+    }
+
+    return <Circle className={styles.stepiconunresolved} />;
+
+}
+  
+
+const Header = ({steps}) => {
+    const { activeStep } = useWizard();
+  
+    return (
+        <Stepper activeStep={activeStep} alternativeLabel>
+        {steps.map((step, index) => {
+            const stepProps = {
+                completed: step.completed && !step.skipped,
+                active: activeStep === index,
+            };
+            return <Step key={step.title} { ...stepProps}>
+                <StepLabel StepIconComponent={SelfServiceStepIcon}>{step.title} {step.optional && (<><br /><span>(optional)</span></>)}</StepLabel>
+            </Step>
+            })}
+</Stepper>
+    );
+
+}
+
+const Footer = ({onAddCapabilityClicked, steps, canContinue}) => {
+    const { previousStep, nextStep, activeStep, stepCount } = useWizard();
+
+    return (
+        <div>
+            {(activeStep > 0) && <Button
+                className={styles.backButton}
+                onClick={() => {
+                    steps[activeStep-1].skipped=false;
+                    steps[activeStep-1].completed=false;
+                    if (activeStep + 1 === stepCount) { // last step; activeStep is 0-based
+                        steps[activeStep].completed=false;
+                    };
+                    previousStep()
+                }}
+                variation="secondary"
+                size="small"
+            >
+                Back
+            </Button>}
+            {(activeStep + 1 < stepCount) && <Button
+                className={styles.nextButton}
+                disabled={!canContinue}
+                onClick={() => {
+                    steps[activeStep].skipped=false;
+                    steps[activeStep].completed=true;
+                    if (activeStep + 2 === stepCount) { // next step is last step; activeStep is 0-based
+                        steps[activeStep+1].completed=true;
+                    };
+                    nextStep()
+                }}
+                variation="primary"
+                size="small"
+            >
+                Next
+            </Button>}
+            {(activeStep + 1 < stepCount) && steps[activeStep].optional && <Button
+                className={styles.skipButton}
+                onClick={() => {
+                    steps[activeStep].skipped=true;
+                    steps[activeStep].completed=true;  
+                    if (activeStep + 2 === stepCount) { // next step is last step; activeStep is 0-based
+                        steps[activeStep+1].completed=true;
+                    };  
+                    nextStep()
+                }}
+                variation="outlined"
+                size="small"
+            >
+                Skip
+            </Button>}
+            {(activeStep + 1 === stepCount) && <Button
+                className={styles.nextButton}
+                onClick={() => {
+                    onAddCapabilityClicked()
+                }}
+                variation="primary"
+                size="small"
+            >
+                Add Capability
+            </Button>}
+        </div>
+    );
+}
+
+const WizardStep = ({steps}) => {
+    const { handleStep, activeStep , stepCount} = useWizard();
+
+    handleStep(() => {
+        //console.log('Going to step ' + activeStep + 2);
+    })
+    
+
+    return (
+      <>
+        <h1>Step {activeStep + 1} of {stepCount}</h1>
+      </>
+    );
+};
+
+const BasicInformationStep = ({formValues, setFormValues, setCanContinue}) => {
+    const [formData, setFormData] = useState(formValues);
+    const [formValid, setFormValid] = useState(false);
+    const [descriptionError, setDescriptionError] = useState("");
+    const [nameError, setNameError] = useState("");
+   
+    const changeName = (e) => {
+        e.preventDefault();
+        let newName = e?.target?.value || "";
+        newName = newName.replace(/\s+/g, "-");
+        setFormData((prev) => ({ ...prev, ...{ name: newName.toLowerCase() } }));
+        validateName(newName);
+    };
+
+    const validateName = (name) => {
+        const isNameValid =
+        name !== "" &&
+        !name.match(/^\s*$/g) &&
+        !name.match(/(_|-)$/g) &&
+        !name.match(/^(_|-)/g) &&
+        !name.match(/[-_.]{2,}/g) &&
+        !name.match(/[^a-zA-Z0-9\-_]/g);
+
+        if (name.length === 0) {
+            setNameError("");
+            return false;
+        }
+
+        if (!isNameValid) {
+            setNameError('Allowed characters are a-z, 0-9, "-", and "_" and it must not start or end with "_" or "-". Do not use more than one of "-" or "_" in a row.');
+            return false;
+        }
+        if (name.length > 150) {
+            setNameError("Please consider a shorter name.");
+            return false;
+        }
+
+        setNameError("");
+        return true;
+    }
+
+    const changeDescription = (e) => {
+        e.preventDefault();
+        const newDescription = e?.target?.value || "";
+        setFormData((prev) => ({ ...prev, ...{ description: newDescription } }));
+        validateDescription(newDescription)
+    };
+
+    const validateDescription = (description) => {
+        if (description.length === 0) {
+            //setDescriptionError("Please write a description");
+            return false;
+        }
+        setDescriptionError("");
+        return true;
+    }
+
+    useEffect(() => {
+        if (formValid) {
+            setCanContinue(true);
+        } else {
+            setCanContinue(false);
+        }
+    }, [formValid]);
+
+    useEffect(() => {
+        let nameValid = validateName(formData.name);
+        let descriptionValid = validateDescription(formData.description);
+        setFormValid(nameValid && descriptionValid);
+        setFormValues(formData);
+    }, [formData]);
+
+    return (
+        <>
+            <div className={styles.tooltip}>
+              <Tooltip content='It is recommended to use "-" (dashes) to separate words in a multi word Capability name (e.g. foo-bar instead of foo_bar).'>
+              </Tooltip>
+            </div>
+            <TextField
+              label="Name"
+              placeholder="Enter name of capability"
+              required
+              value={formData.name}
+              onChange={changeName}
+              errorMessage={nameError}
+              maxLength={255}
+            />
+            <TextField
+                label="Description"
+                placeholder="Enter a description"
+                required
+                value={formData.description}
+                onChange={changeDescription}
+                errorMessage={descriptionError}
+            ></TextField>
+        </>
+    )
+}
+
+const MandatoryTagsStep = ({formValues, setFormValues, setCanContinue}) => {
+    const [formData, setFormData] = useState(formValues);
+    const [formValid, setFormValid] = useState(false);
+
+    useEffect(() => {
+        if (formValid) {
+            setCanContinue(true);
+        } else {
+            setCanContinue(false);
+        }
+    }, [formValid]);
+
+    const validateMandatoryTags = (tags) => {
+        if (tags.length === 0) {
+            return false;
+        }
+        return true;
+    };
+
+    const changeTags = (e) => {
+        e.preventDefault();
+        let newTags = e?.target?.value || "";
+        setFormData((prev) => ({ ...prev, ...{ mandatoryTags: newTags.toLowerCase() } }));
+        validateMandatoryTags(newTags);
+    };
+
+    useEffect(() => {
+        let tagsValid = validateMandatoryTags(formData.mandatoryTags);
+        setFormValid(tagsValid);
+        setFormValues(formData);
+    }, [formData]);
+
+    return (
+        <>
+            <div className={styles.tooltip}>
+              <Tooltip content='It is recommended to use "-" (dashes) to separate words in a multi word Capability name (e.g. foo-bar instead of foo_bar).'>
+              </Tooltip>
+            </div>
+            <TextField
+              label="Tags"
+              placeholder="Commaseparated list of tags"
+              required
+              value={formData.mandatoryTags}
+              onChange={changeTags}
+              //errorMessage={tagsError}
+              maxLength={255}
+            />
+        </>
+    )
+}

--- a/src/src/pages/capabilities/NewCapabilityWizard.js
+++ b/src/src/pages/capabilities/NewCapabilityWizard.js
@@ -2,358 +2,227 @@ import React, { useState, useContext, createRef, useEffect } from "react";
 import { Button } from "@dfds-ui/react-components";
 import { Tooltip, TextField } from "@dfds-ui/react-components";
 import styles from "./capabilities.module.css";
-import { Wizard, useWizard } from 'react-use-wizard';
-import { Modal } from "@dfds-ui/modal";
-import Stepper from '@mui/material/Stepper';
-import Step from '@mui/material/Step';
-import StepLabel from '@mui/material/StepLabel';
-import Check from '@mui/icons-material/Check';
-import Circle from '@mui/icons-material/Circle';
+import { Wizard, useWizard } from "react-use-wizard";
+import CreationWizard from "../../CreationWizard";
 
 export default function NewCapabilityWizard({
   inProgress,
   onAddCapabilityClicked,
   onCloseClicked,
 }) {
-    const emptyFormValues = {
-        name: "",
-        description: "",
-        mandatoryTags: "",
-    };
-
-    const [canContinue, setCanContinue] = useState(true);
-    const [formValues, setFormValues] = useState(emptyFormValues)
-
-    let steps = [
+  const steps = [
     {
-        title: "Basic Information",
-        content: (props) => <BasicInformationStep {...props} />,
-        optional: false,
-        skipped: false,
+      title: "Basic Information",
+      content: (props) => <BasicInformationStep {...props} />,
+      optional: false,
+      skipped: false,
     },
     {
-        title: "Tags",
-        content: (props) => <MandatoryTagsStep {...props} />,
-        optional: false,
-        skipped: false,
+      title: "Tags",
+      content: (props) => <MandatoryTagsStep {...props} />,
+      optional: false,
+      skipped: false,
     },
     {
-        title: "Additional Tags",
-        content: (props) => <WizardStep {...props} />,
-        optional: true,
-        skipped: false,
+      title: "Additional Tags",
+      content: (props) => <WizardStep {...props} />,
+      optional: true,
+      skipped: false,
     },
     {
-        title: "AWS and Azure",
-        content: (props) => <WizardStep {...props} />,
-        optional: true,
-        skipped: false,
+      title: "AWS and Azure",
+      content: (props) => <WizardStep {...props} />,
+      optional: true,
+      skipped: false,
     },
     {
-        title: "Invitations",
-        content: (props) => <WizardStep {...props} />,
-        optional: true,
-        skipped: false,
+      title: "Invitations",
+      content: (props) => <WizardStep {...props} />,
+      optional: true,
+      skipped: false,
     },
     {
-        title: "Summary",
-        content: (props) => <WizardStep {...props} />,
+      title: "Summary",
+      content: (props) => <WizardStep {...props} />,
     },
-    ].slice();
+  ];
 
   return (
-    <Modal
-        heading={"New Capability Wizard"}
-        isOpen={true}
-        shouldCloseOnOverlayClick={false}
-        shouldCloseOnEsc={true}
-        showClose={true}
-        fixedTopPosition={true}
-        onRequestClose={() => onCloseClicked()}
-        sizes={{
-            s: "75%",
-            m: "75%",
-            l: "75%",
-            xl: "75%",
-            xxl: "75%",
-        }}
-    >
-        <Wizard
-            startIndex={0}
-            header={<Header steps={steps} />}
-            footer={<Footer onAddCapabilityClicked={onAddCapabilityClicked} steps={steps} canContinue={canContinue} />}
-        >
-            {steps.map((step) => (
-                <div key={step.title}>
-                    {step.content({formValues, setFormValues, setCanContinue})}
-                </div>
-            ))}
-        </Wizard>
-    </Modal>
+    <CreationWizard
+      isOpen={true}
+      onClose={onCloseClicked}
+      onComplete={onAddCapabilityClicked}
+      steps={steps}
+      title="New Capability Wizard"
+    />
   );
 }
 
-function SelfServiceStepIcon(props) {
-    const { completed, active } = props;
+const BasicInformationStep = ({
+  formValues,
+  setFormValues,
+  setCanContinue,
+}) => {
+  const [formData, setFormData] = useState(formValues);
+  const [formValid, setFormValid] = useState(false);
+  const [descriptionError, setDescriptionError] = useState("");
+  const [nameError, setNameError] = useState("");
 
-    if (completed) {
-      return <Check className={styles.stepiconcompleted} />;
+  const changeName = (e) => {
+    e.preventDefault();
+    let newName = e?.target?.value || "";
+    newName = newName.replace(/\s+/g, "-");
+    setFormData((prev) => ({ ...prev, ...{ name: newName.toLowerCase() } }));
+    validateName(newName);
+  };
+
+  const validateName = (name) => {
+    const isNameValid =
+      name !== "" &&
+      !name.match(/^\s*$/g) &&
+      !name.match(/(_|-)$/g) &&
+      !name.match(/^(_|-)/g) &&
+      !name.match(/[-_.]{2,}/g) &&
+      !name.match(/[^a-zA-Z0-9\-_]/g);
+
+    if (name.length === 0) {
+      setNameError("");
+      return false;
     }
 
-    if (active) {
-      return <Circle className={styles.stepiconactive} />;
+    if (!isNameValid) {
+      setNameError(
+        'Allowed characters are a-z, 0-9, "-", and "_" and it must not start or end with "_" or "-". Do not use more than one of "-" or "_" in a row.',
+      );
+      return false;
+    }
+    if (name.length > 150) {
+      setNameError("Please consider a shorter name.");
+      return false;
     }
 
-    return <Circle className={styles.stepiconunresolved} />;
+    setNameError("");
+    return true;
+  };
 
-}
-  
+  const changeDescription = (e) => {
+    e.preventDefault();
+    const newDescription = e?.target?.value || "";
+    setFormData((prev) => ({ ...prev, ...{ description: newDescription } }));
+    validateDescription(newDescription);
+  };
 
-const Header = ({steps}) => {
-    const { activeStep } = useWizard();
-  
-    return (
-        <Stepper activeStep={activeStep} alternativeLabel>
-        {steps.map((step, index) => {
-            const stepProps = {
-                completed: step.completed && !step.skipped,
-                active: activeStep === index,
-            };
-            return <Step key={step.title} { ...stepProps}>
-                <StepLabel StepIconComponent={SelfServiceStepIcon}>{step.title} {step.optional && (<><br /><span>(optional)</span></>)}</StepLabel>
-            </Step>
-            })}
-</Stepper>
-    );
+  const validateDescription = (description) => {
+    if (description.length === 0) {
+      //setDescriptionError("Please write a description");
+      return false;
+    }
+    setDescriptionError("");
+    return true;
+  };
 
-}
+  useEffect(() => {
+    if (formValid) {
+      setCanContinue(true);
+    } else {
+      setCanContinue(false);
+    }
+  }, [formValid]);
 
-const Footer = ({onAddCapabilityClicked, steps, canContinue}) => {
-    const { previousStep, nextStep, activeStep, stepCount } = useWizard();
+  useEffect(() => {
+    let nameValid = validateName(formData.name);
+    let descriptionValid = validateDescription(formData.description);
+    setFormValid(nameValid && descriptionValid);
+    setFormValues(formData);
+  }, [formData]);
 
-    return (
-        <div>
-            {(activeStep > 0) && <Button
-                className={styles.backButton}
-                onClick={() => {
-                    steps[activeStep-1].skipped=false;
-                    steps[activeStep-1].completed=false;
-                    if (activeStep + 1 === stepCount) { // last step; activeStep is 0-based
-                        steps[activeStep].completed=false;
-                    };
-                    previousStep()
-                }}
-                variation="secondary"
-                size="small"
-            >
-                Back
-            </Button>}
-            {(activeStep + 1 < stepCount) && <Button
-                className={styles.nextButton}
-                disabled={!canContinue}
-                onClick={() => {
-                    steps[activeStep].skipped=false;
-                    steps[activeStep].completed=true;
-                    if (activeStep + 2 === stepCount) { // next step is last step; activeStep is 0-based
-                        steps[activeStep+1].completed=true;
-                    };
-                    nextStep()
-                }}
-                variation="primary"
-                size="small"
-            >
-                Next
-            </Button>}
-            {(activeStep + 1 < stepCount) && steps[activeStep].optional && <Button
-                className={styles.skipButton}
-                onClick={() => {
-                    steps[activeStep].skipped=true;
-                    steps[activeStep].completed=true;  
-                    if (activeStep + 2 === stepCount) { // next step is last step; activeStep is 0-based
-                        steps[activeStep+1].completed=true;
-                    };  
-                    nextStep()
-                }}
-                variation="outlined"
-                size="small"
-            >
-                Skip
-            </Button>}
-            {(activeStep + 1 === stepCount) && <Button
-                className={styles.nextButton}
-                onClick={() => {
-                    onAddCapabilityClicked()
-                }}
-                variation="primary"
-                size="small"
-            >
-                Add Capability
-            </Button>}
-        </div>
-    );
-}
-
-const WizardStep = ({steps}) => {
-    const { handleStep, activeStep , stepCount} = useWizard();
-
-    handleStep(() => {
-        //console.log('Going to step ' + activeStep + 2);
-    })
-    
-
-    return (
-      <>
-        <h1>Step {activeStep + 1} of {stepCount}</h1>
-      </>
-    );
+  return (
+    <>
+      <div className={styles.tooltip}>
+        <Tooltip content='It is recommended to use "-" (dashes) to separate words in a multi word Capability name (e.g. foo-bar instead of foo_bar).'></Tooltip>
+      </div>
+      <TextField
+        label="Name"
+        placeholder="Enter name of capability"
+        required
+        value={formData.name}
+        onChange={changeName}
+        errorMessage={nameError}
+        maxLength={255}
+      />
+      <TextField
+        label="Description"
+        placeholder="Enter a description"
+        required
+        value={formData.description}
+        onChange={changeDescription}
+        errorMessage={descriptionError}
+      ></TextField>
+    </>
+  );
 };
 
-const BasicInformationStep = ({formValues, setFormValues, setCanContinue}) => {
-    const [formData, setFormData] = useState(formValues);
-    const [formValid, setFormValid] = useState(false);
-    const [descriptionError, setDescriptionError] = useState("");
-    const [nameError, setNameError] = useState("");
-   
-    const changeName = (e) => {
-        e.preventDefault();
-        let newName = e?.target?.value || "";
-        newName = newName.replace(/\s+/g, "-");
-        setFormData((prev) => ({ ...prev, ...{ name: newName.toLowerCase() } }));
-        validateName(newName);
-    };
+const MandatoryTagsStep = ({ formValues, setFormValues, setCanContinue }) => {
+  const [formData, setFormData] = useState(formValues);
+  const [formValid, setFormValid] = useState(false);
 
-    const validateName = (name) => {
-        const isNameValid =
-        name !== "" &&
-        !name.match(/^\s*$/g) &&
-        !name.match(/(_|-)$/g) &&
-        !name.match(/^(_|-)/g) &&
-        !name.match(/[-_.]{2,}/g) &&
-        !name.match(/[^a-zA-Z0-9\-_]/g);
-
-        if (name.length === 0) {
-            setNameError("");
-            return false;
-        }
-
-        if (!isNameValid) {
-            setNameError('Allowed characters are a-z, 0-9, "-", and "_" and it must not start or end with "_" or "-". Do not use more than one of "-" or "_" in a row.');
-            return false;
-        }
-        if (name.length > 150) {
-            setNameError("Please consider a shorter name.");
-            return false;
-        }
-
-        setNameError("");
-        return true;
+  useEffect(() => {
+    if (formValid) {
+      setCanContinue(true);
+    } else {
+      setCanContinue(false);
     }
+  }, [formValid]);
 
-    const changeDescription = (e) => {
-        e.preventDefault();
-        const newDescription = e?.target?.value || "";
-        setFormData((prev) => ({ ...prev, ...{ description: newDescription } }));
-        validateDescription(newDescription)
-    };
-
-    const validateDescription = (description) => {
-        if (description.length === 0) {
-            //setDescriptionError("Please write a description");
-            return false;
-        }
-        setDescriptionError("");
-        return true;
+  const validateMandatoryTags = (tags) => {
+    if (tags.length === 0) {
+      return false;
     }
+    return true;
+  };
 
-    useEffect(() => {
-        if (formValid) {
-            setCanContinue(true);
-        } else {
-            setCanContinue(false);
-        }
-    }, [formValid]);
+  const changeTags = (e) => {
+    e.preventDefault();
+    let newTags = e?.target?.value || "";
+    setFormData((prev) => ({
+      ...prev,
+      ...{ mandatoryTags: newTags.toLowerCase() },
+    }));
+    validateMandatoryTags(newTags);
+  };
 
-    useEffect(() => {
-        let nameValid = validateName(formData.name);
-        let descriptionValid = validateDescription(formData.description);
-        setFormValid(nameValid && descriptionValid);
-        setFormValues(formData);
-    }, [formData]);
+  useEffect(() => {
+    let tagsValid = validateMandatoryTags(formData.mandatoryTags);
+    setFormValid(tagsValid);
+    setFormValues(formData);
+  }, [formData]);
 
-    return (
-        <>
-            <div className={styles.tooltip}>
-              <Tooltip content='It is recommended to use "-" (dashes) to separate words in a multi word Capability name (e.g. foo-bar instead of foo_bar).'>
-              </Tooltip>
-            </div>
-            <TextField
-              label="Name"
-              placeholder="Enter name of capability"
-              required
-              value={formData.name}
-              onChange={changeName}
-              errorMessage={nameError}
-              maxLength={255}
-            />
-            <TextField
-                label="Description"
-                placeholder="Enter a description"
-                required
-                value={formData.description}
-                onChange={changeDescription}
-                errorMessage={descriptionError}
-            ></TextField>
-        </>
-    )
-}
+  return (
+    <>
+      <div className={styles.tooltip}>
+        <Tooltip content='It is recommended to use "-" (dashes) to separate words in a multi word Capability name (e.g. foo-bar instead of foo_bar).'></Tooltip>
+      </div>
+      <TextField
+        label="Tags"
+        placeholder="Commaseparated list of tags"
+        required
+        value={formData.mandatoryTags}
+        onChange={changeTags}
+        //errorMessage={tagsError}
+        maxLength={255}
+      />
+    </>
+  );
+};
 
-const MandatoryTagsStep = ({formValues, setFormValues, setCanContinue}) => {
-    const [formData, setFormData] = useState(formValues);
-    const [formValid, setFormValid] = useState(false);
+const WizardStep = ({ steps }) => {
+  const { activeStep, stepCount } = useWizard();
 
-    useEffect(() => {
-        if (formValid) {
-            setCanContinue(true);
-        } else {
-            setCanContinue(false);
-        }
-    }, [formValid]);
-
-    const validateMandatoryTags = (tags) => {
-        if (tags.length === 0) {
-            return false;
-        }
-        return true;
-    };
-
-    const changeTags = (e) => {
-        e.preventDefault();
-        let newTags = e?.target?.value || "";
-        setFormData((prev) => ({ ...prev, ...{ mandatoryTags: newTags.toLowerCase() } }));
-        validateMandatoryTags(newTags);
-    };
-
-    useEffect(() => {
-        let tagsValid = validateMandatoryTags(formData.mandatoryTags);
-        setFormValid(tagsValid);
-        setFormValues(formData);
-    }, [formData]);
-
-    return (
-        <>
-            <div className={styles.tooltip}>
-              <Tooltip content='It is recommended to use "-" (dashes) to separate words in a multi word Capability name (e.g. foo-bar instead of foo_bar).'>
-              </Tooltip>
-            </div>
-            <TextField
-              label="Tags"
-              placeholder="Commaseparated list of tags"
-              required
-              value={formData.mandatoryTags}
-              onChange={changeTags}
-              //errorMessage={tagsError}
-              maxLength={255}
-            />
-        </>
-    )
-}
+  return (
+    <>
+      <h1>
+        Step {activeStep + 1} of {stepCount}
+      </h1>
+    </>
+  );
+};

--- a/src/src/pages/capabilities/capabilities.module.css
+++ b/src/src/pages/capabilities/capabilities.module.css
@@ -85,3 +85,36 @@
   top: -16px;
   flex-wrap: wrap;
 }
+
+.nextButton {
+  margin-top: 20px;
+  float: right;
+}
+
+.skipButton {
+  margin-top: 20px;
+  margin-right: 20px;
+  float: right;
+}
+
+.backButton {
+  margin-top: 20px;
+  float: left;
+}
+
+.stepiconcompleted {
+  color: #4caf50;
+}
+
+.stepiconunresolved {
+  color: #7e8386;
+}
+
+.stepiconactive {
+  color: #ed8800;
+}
+
+.stepiconskipped {
+  color: #153b53;
+  size: 0.5em;
+}

--- a/src/src/pages/capabilities/index.js
+++ b/src/src/pages/capabilities/index.js
@@ -9,13 +9,15 @@ import {
 } from "@dfds-ui/react-components";
 import styles from "./capabilities.module.css";
 import AppContext from "AppContext";
-import NewCapabilityDialog from "./NewCapabilityDialog";
+//import NewCapabilityDialog from "./NewCapabilityDialog";
+import NewCapabilityWizard from "./NewCapabilityWizard";
 import MyCapabilities from "./MyCapabilities";
 import MyInvitations from "../../components/invitations/MyInvitations";
 import OtherCapabilities from "./OtherCapabilities";
 import { MembershipApplicationsUserCanApprove } from "./membershipapplications/index";
 import Page from "components/Page";
 import SplashImage from "./splash.jpg";
+import { set } from "date-fns";
 
 export default function CapabilitiesPage() {
   const { addNewCapability, myProfile } = useContext(AppContext);
@@ -24,6 +26,8 @@ export default function CapabilitiesPage() {
   const { reloadUser } = useContext(AppContext);
 
   const handleAddCapability = async (formData) => {
+
+    /*
     setIsCreatingNewCapability(true);
     await addNewCapability(
       formData.name,
@@ -34,6 +38,9 @@ export default function CapabilitiesPage() {
     setShowNewCapabilityDialog(false);
     setIsCreatingNewCapability(false);
     reloadUser();
+    */
+   alert("You asked to create a new capability");
+   setShowNewCapabilityDialog(false);
   };
 
   const splash = (
@@ -48,7 +55,7 @@ export default function CapabilitiesPage() {
     <>
       <Page title="Capabilities">
         {showNewCapabilityDialog && (
-          <NewCapabilityDialog
+          <NewCapabilityWizard
             inProgress={isCreatingNewCapability}
             onAddCapabilityClicked={handleAddCapability}
             onCloseClicked={() => setShowNewCapabilityDialog(false)}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3cc75a65-155d-4d0f-ae47-154a8bf8ddab)

# Why and why and why
Guiding users through a wizard allows us to give context to each step and make each step less overwhelming.

Having a thorough wizard with skippable elements can help us showcase what we offer, and may teach this to users.

Behind the scenes the wizard could fill out a Capability State JSON, which -- if the API can handle this -- could be a good step towards allowing capability setup defined as code.

Now this wizard is nowhere near complete, I know.
But before I spent much more time on it, we should probably agree if this is a way we want to go.