### PR TITLE
Manage required tags and warn about missing ones

### DIFF
--- a/src/src/hooks/Capabilities.js
+++ b/src/src/hooks/Capabilities.js
@@ -288,13 +288,17 @@ export function useCapabilityMetadata(capabilityDefinition) {
 
   const link = capabilityDefinition?._links;
 
-  useEffect(() => {
+  const getMetaData = async () => {
     if (link?.metadata && (link.metadata.allow || []).includes("GET")) {
-      void sendGetJsonMetadataRequest({
+      sendGetJsonMetadataRequest({
         urlSegments: [link.metadata.href],
         method: "GET",
       });
     }
+  };
+
+  useEffect(() => {
+    getMetaData();
   }, [link]);
 
   useEffect(() => {
@@ -320,6 +324,7 @@ export function useCapabilityMetadata(capabilityDefinition) {
         jsonMetadata: JSON.parse(jsonMetadata),
       },
     });
+    getMetaData();
   };
 
   const setRequiredCapabilityJsonMetadata = async (jsonMetadata) => {
@@ -338,6 +343,7 @@ export function useCapabilityMetadata(capabilityDefinition) {
         jsonMetadata: JSON.parse(jsonMetadata),
       },
     });
+    getMetaData();
   };
 
   return {


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2968

# Additional Review Notes
This solution is not 'good', but we have a tight deadline.
We should not have hardcoded things like this in the API and the frontend, when we also manage tags via a different repository.

For now it does a thing, though

![image](https://github.com/user-attachments/assets/d612b425-d613-45c7-bf16-11f53f20a63a)
![image](https://github.com/user-attachments/assets/7f42f779-081f-47e0-b9ef-c5b7f4191203)
