### PR TITLE
Fixing capability page

### DIFF
--- a/src/src/AppContext.jsx
+++ b/src/src/AppContext.jsx
@@ -72,6 +72,8 @@ function AppProvider({ children }) {
   const [myCapabilities, setMyCapabilities] = useState([]);
   const { data: me, isFetched: isMeFetched } = useMe();
   const { isCloudEngineerEnabled } = useContext(PreAppContext);
+  const [showOnlyMyCapabilities, setShowOnlyMyCapabilities] = useState(true);
+  const [globalFilter, setGlobalFilter] = useState("");
 
   const [stats, setStats] = useState([]);
   const news = useLatestNews();
@@ -230,6 +232,10 @@ function AppProvider({ children }) {
     isAllWithValues,
     getValidationError,
     checkIfCloudEngineer,
+    showOnlyMyCapabilities,
+    setShowOnlyMyCapabilities,
+    globalFilter,
+    setGlobalFilter,
   };
 
   return <AppContext.Provider value={state}>{children}</AppContext.Provider>;

--- a/src/src/AppContext.jsx
+++ b/src/src/AppContext.jsx
@@ -74,6 +74,7 @@ function AppProvider({ children }) {
   const { isCloudEngineerEnabled } = useContext(PreAppContext);
   const [showOnlyMyCapabilities, setShowOnlyMyCapabilities] = useState(true);
   const [globalFilter, setGlobalFilter] = useState("");
+  const [showDeletedCapabilities, setShowDeletedCapabilities] = useState(false);
 
   const [stats, setStats] = useState([]);
   const news = useLatestNews();
@@ -236,6 +237,8 @@ function AppProvider({ children }) {
     setShowOnlyMyCapabilities,
     globalFilter,
     setGlobalFilter,
+    showDeletedCapabilities,
+    setShowDeletedCapabilities,
   };
 
   return <AppContext.Provider value={state}>{children}</AppContext.Provider>;

--- a/src/src/pages/capabilities/Capabilities.jsx
+++ b/src/src/pages/capabilities/Capabilities.jsx
@@ -29,7 +29,7 @@ function CapabilitiesTable({ columns, filteredCapabilities, clickHandler }) {
         globalFilter: globalFilter,
       }}
       onGlobalFilterChange={(value) => {
-          setGlobalFilter(value);
+        setGlobalFilter(value);
       }}
       muiTableHeadCellProps={{
         sx: {
@@ -113,7 +113,13 @@ function CapabilitiesTable({ columns, filteredCapabilities, clickHandler }) {
 }
 
 export default function CapabilitiesList() {
-  const { truncateString, showDeletedCapabilities, setShowDeletedCapabilities, showOnlyMyCapabilities, setShowOnlyMyCapabilities } = useContext(AppContext);
+  const {
+    truncateString,
+    showDeletedCapabilities,
+    setShowDeletedCapabilities,
+    showOnlyMyCapabilities,
+    setShowOnlyMyCapabilities,
+  } = useContext(AppContext);
   const { isCloudEngineerEnabled } = useContext(PreAppContext);
   const { isFetched: isCapabilityFetched, data: capabilitiesData } =
     useCapabilities();
@@ -138,28 +144,33 @@ export default function CapabilitiesList() {
   useEffect(() => {
     if (capabilities) {
       if (showOnlyMyCapabilities && myCapabilities) {
+        if (showDeletedCapabilities) {
           setFilteredCapabilities(myCapabilities);
+        } else {
+          setFilteredCapabilities(
+            myCapabilities.filter((capability) => {
+              return capability.status !== "Deleted";
+            }),
+          );
+        }
       } else {
-        setFilteredCapabilities(capabilities);
+        if (showDeletedCapabilities) {
+          setFilteredCapabilities(capabilities);
+        } else {
+          setFilteredCapabilities(
+            capabilities.filter((capability) => {
+              return capability.status !== "Deleted";
+            }),
+          );
+        }
       }
     }
-  }, [capabilities, myCapabilities, showOnlyMyCapabilities]);
-
-  useEffect(() => {
-    if (isCapabilityFetched && capabilities) {
-      if (showDeletedCapabilities) {
-        console.log("Showing all capabilities including deleted ones");
-        setFilteredCapabilities(capabilities);
-      } else {
-        console.log("Filtering deleted capabilities");
-        setFilteredCapabilities(
-          capabilities.filter((capability) => {
-            return capability.status !== "Deleted";
-          }),
-        );
-      }
-    }
-  }, [showDeletedCapabilities]);
+  }, [
+    capabilities,
+    myCapabilities,
+    showOnlyMyCapabilities,
+    showDeletedCapabilities,
+  ]);
 
   useEffect(() => {
     if (isCapabilityFetched) {
@@ -354,7 +365,7 @@ export default function CapabilitiesList() {
   );
 
   const toggleShowMyCapabilities = () => {
-    setShowMyCapabilities(!showMyCapabilities);
+    setShowOnlyMyCapabilities(!showOnlyMyCapabilities);
   };
 
   const toggleShowDeletedCapabilities = () => {
@@ -372,26 +383,28 @@ export default function CapabilitiesList() {
               })`
         }`}
         headlineChildren={
-          isLoading ? null : (<>
-            <div className={styles.myCapabilitiesToggleBox}>
-              <span className={styles.myCapabilitiesToggleTitle}>
-                Show just mine:{" "}
-              </span>
-              <Switch
-                checked={showOnlyMyCapabilities}
-                onChange={toggleShowMyCapabilities}
-              />
-            </div>
-            {isCloudEngineerEnabled && (
-            <div className={styles.myCapabilitiesToggleBox}>
-              <span className={styles.myCapabilitiesToggleTitle}>
-                Show deleted capabilities:{" "}
-              </span>
-              <Switch
-                checked={showDeletedCapabilities}
-                onChange={toggleShowDeletedCapabilities}
-              />
-            </div>)}
+          isLoading ? null : (
+            <>
+              <div className={styles.myCapabilitiesToggleBox}>
+                <span className={styles.myCapabilitiesToggleTitle}>
+                  Show just mine:{" "}
+                </span>
+                <Switch
+                  checked={showOnlyMyCapabilities}
+                  onChange={toggleShowMyCapabilities}
+                />
+              </div>
+              {isCloudEngineerEnabled && (
+                <div className={styles.myCapabilitiesToggleBox}>
+                  <span className={styles.myCapabilitiesToggleTitle}>
+                    Show deleted capabilities:{" "}
+                  </span>
+                  <Switch
+                    checked={showDeletedCapabilities}
+                    onChange={toggleShowDeletedCapabilities}
+                  />
+                </div>
+              )}
             </>
           )
         }

--- a/src/src/pages/capabilities/Capabilities.jsx
+++ b/src/src/pages/capabilities/Capabilities.jsx
@@ -5,7 +5,6 @@ import { ChevronRight, StatusAlert } from "@dfds-ui/icons/system";
 import { Spinner } from "@dfds-ui/react-components";
 import AppContext from "AppContext";
 import PageSection from "components/PageSection";
-import { useMe } from "@/state/remote/queries/me";
 import { useCapabilities } from "@/state/remote/queries/capabilities";
 import { Switch } from "@dfds-ui/forms";
 import styles from "./capabilities.module.css";
@@ -14,6 +13,8 @@ import CapabilityCostSummary from "components/BasicCapabilityCost";
 //import { InlineAwsCountSummary } from "pages/capabilities/AwsResourceCount";
 
 function CapabilitiesTable({ columns, filteredCapabilities, clickHandler }) {
+  const { globalFilter, setGlobalFilter } = useContext(AppContext);
+
   return (
     <MaterialReactTable
       columns={columns}
@@ -22,6 +23,12 @@ function CapabilitiesTable({ columns, filteredCapabilities, clickHandler }) {
         pagination: { pageSize: 50 },
         showGlobalFilter: true,
         columnVisibility: { AwsAccountId: false },
+      }}
+      state={{
+        globalFilter: globalFilter,
+      }}
+      onGlobalFilterChange={(value) => {
+          setGlobalFilter(value);
       }}
       muiTableHeadCellProps={{
         sx: {
@@ -105,11 +112,9 @@ function CapabilitiesTable({ columns, filteredCapabilities, clickHandler }) {
 }
 
 export default function CapabilitiesList() {
-  const { truncateString } = useContext(AppContext);
+  const { truncateString, showOnlyMyCapabilities, setShowOnlyMyCapabilities } = useContext(AppContext);
   const { isFetched: isCapabilityFetched, data: capabilitiesData } =
     useCapabilities();
-
-  const [showOnlyMyCapabilities, setShowOnlyMyCapabilities] = useState(true);
 
   const [isLoading, setIsLoading] = useState(true);
 

--- a/src/src/pages/capabilities/Capabilities.jsx
+++ b/src/src/pages/capabilities/Capabilities.jsx
@@ -13,7 +13,7 @@ import { MaterialReactTable } from "material-react-table";
 import CapabilityCostSummary from "components/BasicCapabilityCost";
 //import { InlineAwsCountSummary } from "pages/capabilities/AwsResourceCount";
 
-function CapabilitiesTable({ columns, filteredCapabilities, clickHandler }) {
+function CapabilitiesTable({ columns, filteredCapabilities }) {
   const { globalFilter, setGlobalFilter } = useContext(AppContext);
 
   return (
@@ -90,10 +90,11 @@ function CapabilitiesTable({ columns, filteredCapabilities, clickHandler }) {
       }}
       muiTableBodyRowProps={({ row }) => {
         return {
-          onClick: () => {
-            clickHandler(row.original.id);
-          },
+          component: "a",
+          href: `/capabilities/${row.original.id}`,
           sx: {
+            textDecoration: "none",
+            color: "inherit",
             cursor: "pointer",
             background: row.original.status === "Deleted" ? "#d88" : "",
             padding: 0,
@@ -177,9 +178,6 @@ export default function CapabilitiesList() {
       setIsLoading(false);
     }
   }, [isCapabilityFetched]);
-
-  const navigate = useNavigate();
-  const clickHandler = (id) => navigate(`/capabilities/${id}`);
 
   const columns = useMemo(
     () => [
@@ -415,7 +413,6 @@ export default function CapabilitiesList() {
           <CapabilitiesTable
             columns={columns}
             filteredCapabilities={filteredCapabilities}
-            clickHandler={clickHandler}
           />
         )}
       </PageSection>


### PR DESCRIPTION
 * Capability rows are now links
 * Cloud engineers can toggle deleted capabilities
 * Filter and my-capabilities toggle are now remembered when navigating