### PR TITLE
Prevent committing too long descriptions

### DIFF
--- a/src/src/pages/capabilities/NewCapabilityWizard.jsx
+++ b/src/src/pages/capabilities/NewCapabilityWizard.jsx
@@ -570,7 +570,8 @@ const SummaryStep = ({ formValues }) => {
       </p>
       <h2>Mandatory Tags</h2>
       <p>
-        <strong>Owner:</strong> {formValues.mandatoryTags["dfds.owner"] || "Not provided"}
+        <strong>Owner:</strong>{" "}
+        {formValues.mandatoryTags["dfds.owner"] || "Not provided"}
       </p>
       <p>
         <strong>Cost Center:</strong>{" "}


### PR DESCRIPTION
Fix: prevent committing too long description names
Bonus: improved look of summary (to fit potential long lines)

# Additional Review Notes
<img width="1439" height="849" alt="image" src="https://github.com/user-attachments/assets/b7b821b7-eb9f-4cf0-832c-9e31bae1b7bc" />
