### PR TITLE
Align dropdown labels with wiki

### DIFF
--- a/src/src/constants/tagConstants.jsx
+++ b/src/src/constants/tagConstants.jsx
@@ -41,19 +41,19 @@ export const ENUM_CLASSIFICATION_OPTIONS = ENUM_CLASSIFICATION.map((item) => ({
 
 export const ENUM_AZURERG_USAGE = [
   {
-    label: "EntraID, Office365, Dynamics365, PowerBI, etc.",
+    label: "Core DFDS Infrasctructure",
     value: "ToolAccess",
   },
-  { label: "OpenAI Services", value: "AI" },
+  { label: "Azure OpenAI Services", value: "AI" },
   {
-    label: "Third party SaaS limited to Azure",
+    label: "Native Integrations",
     value: "ThirdPartyLimitations",
   },
   {
-    label: "Partner packages with tigh Azure coupling",
+    label: "Third-party SaaS",
     value: "PartnerPackageLimitation",
   },
-  { label: "Other", value: "Other" },
+  { label: "Partner Packages", value: "Other" },
 ];
 export const ENUM_AZURERG_USAGE_OPTIONS = ENUM_AZURERG_USAGE.map((item) => ({
   value: item.value.toLowerCase(),


### PR DESCRIPTION
# Changes
Change the name of the Azure Group Purpose dropdown to match description from the wiki.

# Additional Review Notes
New drop down and wiki screenshots:
<img width="896" height="438" alt="image" src="https://github.com/user-attachments/assets/5bcb9a85-8b5c-4eef-a37d-0796649a422f" />

<img width="1325" height="346" alt="image" src="https://github.com/user-attachments/assets/41b649b2-8055-4235-b4b2-f1c631ecf9c4" />
