### PR TITLE
DateFlag min-width allows it to stay in shape

### DIFF
--- a/src/src/components/DateFlag/DateFlag.jsx
+++ b/src/src/components/DateFlag/DateFlag.jsx
@@ -27,7 +27,7 @@ const styles = {
     borderRadius: "6px",
     overflow: "hidden",
     fontFamily: "sans-serif",
-    width: "70px",
+    minWidth: "70px",
     boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
   },
   top: {


### PR DESCRIPTION
# Additional Review Notes
This was never tested for our other use case, but now we found something