### PR TITLE
Reload all information when cloudEngineer is toggled

### DIFF
--- a/src/src/AppContext.jsx
+++ b/src/src/AppContext.jsx
@@ -96,7 +96,12 @@ function AppProvider({ children }) {
     queryClient.invalidateQueries({ queryKey: ["me"] });
     queryClient.invalidateQueries({ queryKey: ["capabilities", "list"] });
     queryClient.invalidateQueries({ queryKey: ["selfassessments", "list"] });
-  }, [selfServiceApiClient]);
+    queryClient.invalidateQueries({ queryKey: ["ecr", "repositories"] });
+    queryClient.invalidateQueries({
+      queryKey: ["capabilities", "details"],
+      exact: false,
+    });
+  }, [selfServiceApiClient, isCloudEngineerEnabled]);
 
   const capabilityAdd = useCapabilityAdd();
   const createEcrRepository = useCreateEcrRepository();

--- a/src/src/components/GlobalMenu/GlobalMenu.jsx
+++ b/src/src/components/GlobalMenu/GlobalMenu.jsx
@@ -87,17 +87,6 @@ export default function GlobalMenu() {
     setIsCloudEngineerEnabled((prev) => !prev);
   }
 
-  useEffect(() => {
-    async function updateData() {
-      await sleep(202);
-      queryClient.invalidateQueries({ queryKey: ["capabilities", "list"] });
-      queryClient.invalidateQueries({ queryKey: ["capabilities", "details"] });
-      queryClient.invalidateQueries({ queryKey: ["ecr", "repositories"] });
-      queryClient.invalidateQueries({ queryKey: ["me"] });
-    }
-    updateData();
-  }, [isCloudEngineerEnabled]);
-
   return (
     <>
       <AppBarProvider>


### PR DESCRIPTION
# Changes
- Moved reload away from main menu and into AppContext

This should hopefully prevent strange race condition where data is sometimes loaded before `isCloudEngineer` is set.