### PR TITLE
see permission matrix page

### DIFF
--- a/src/src/App.jsx
+++ b/src/src/App.jsx
@@ -18,6 +18,7 @@ import ReleaseNotesView from "./pages/release-notes/view";
 import EventsPage from "./pages/events";
 import CompliancePage from "./pages/compliance";
 import RbacViewerPage from "./pages/admin/rbac";
+import PermissionMatrixPage from "./pages/rbac";
 import DeletionQueuePage from "./pages/admin/capabilities/deletion-queue";
 import MembershipApplicationsAdminPage from "./pages/admin/membership-applications";
 import UserInspectorPage from "./pages/admin/rbac/user";
@@ -120,9 +121,8 @@ function Layout() {
           </a>
           {/* Mobile backdrop */}
           <div
-            className={`fixed inset-0 bg-black/40 z-40 md:hidden transition-opacity duration-200 ${
-              mobileOpen ? "opacity-100" : "opacity-0 pointer-events-none"
-            }`}
+            className={`fixed inset-0 bg-black/40 z-40 md:hidden transition-opacity duration-200 ${mobileOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+              }`}
             onClick={() => setMobileOpen(false)}
             aria-hidden="true"
           />
@@ -188,6 +188,7 @@ export default function App() {
           <Route path="capabilities/:id" element={<CapabilityDetailsPage />} />
           <Route path="events" element={<EventsPage />} />
           <Route path="compliance" element={<CompliancePage />} />
+          <Route path="rbac/permissions" element={<PermissionMatrixPage />} />
           <Route path="admin/rbac" element={<RbacViewerPage />} />
           <Route path="admin/rbac/user" element={<UserInspectorPage />} />
           <Route

--- a/src/src/components/Sidebar/Sidebar.tsx
+++ b/src/src/components/Sidebar/Sidebar.tsx
@@ -39,6 +39,7 @@ import {
   LineChart,
   Database,
   Mail,
+  Table2,
 } from "lucide-react";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import AppContext from "@/AppContext";
@@ -79,6 +80,7 @@ const platformNav: NavItemDef[] = [
   { title: "Capabilities", url: "/capabilities", icon: Layers },
   { title: "Topics", url: "/topics", icon: List },
   { title: "ECR", url: "/ecr", icon: Package },
+  { title: "Permission Matrix", url: "/rbac/permissions", icon: Table2 },
 ];
 
 const contentNav: NavItemDef[] = [
@@ -269,10 +271,10 @@ const THEME_OPTIONS: {
   icon: React.ElementType;
   label: string;
 }[] = [
-  { value: "light", icon: Sun, label: "Light" },
-  { value: "dark", icon: Moon, label: "Dark" },
-  { value: "system", icon: Monitor, label: "Auto" },
-];
+    { value: "light", icon: Sun, label: "Light" },
+    { value: "dark", icon: Moon, label: "Dark" },
+    { value: "system", icon: Monitor, label: "Auto" },
+  ];
 
 function ThemeToggle() {
   const { theme, setTheme } = useTheme();
@@ -499,9 +501,9 @@ export default function Sidebar({ mobileOpen = false, onClose }: SidebarProps) {
       style={
         isMobile
           ? {
-              transform: mobileOpen ? "translateX(0)" : "translateX(-100%)",
-              transition: "transform 500ms cubic-bezier(0.16, 1, 0.3, 1)",
-            }
+            transform: mobileOpen ? "translateX(0)" : "translateX(-100%)",
+            transition: "transform 500ms cubic-bezier(0.16, 1, 0.3, 1)",
+          }
           : undefined
       }
     >

--- a/src/src/pages/capabilities/members/index.jsx
+++ b/src/src/pages/capabilities/members/index.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { TabbedPageSection } from "../../../components/PageSection";
 import SelectedCapabilityContext from "../SelectedCapabilityContext";
 import AppContext from "../../../AppContext";
@@ -125,17 +126,17 @@ function MemberRow({ member, roleTypes }) {
                     ? "#1d4ed8"
                     : "#0e7cc1"
                   : state.isFocused
-                  ? isDark
-                    ? "#0f172a"
-                    : "#f2f2f2"
-                  : isDark
-                  ? "#1e293b"
-                  : "#ffffff",
+                    ? isDark
+                      ? "#0f172a"
+                      : "#f2f2f2"
+                    : isDark
+                      ? "#1e293b"
+                      : "#ffffff",
                 color: state.isSelected
                   ? "#ffffff"
                   : isDark
-                  ? "#e2e8f0"
-                  : "#002b45",
+                    ? "#e2e8f0"
+                    : "#002b45",
               }),
               indicatorSeparator: (base) => ({
                 ...base,
@@ -198,6 +199,15 @@ export function TabbedMembersView({ anchorId }) {
   const header = <></>;
   const footer = <></>;
 
+  const headlineChildren = (
+    <Link
+      to="/rbac/permissions"
+      className="font-mono text-[11px] text-[#0e7cc1] dark:text-[#60a5fa] hover:underline"
+    >
+      View permission matrix →
+    </Link>
+  );
+
   const applicationCount = (capabilityApplications || []).length;
 
   const tabs = {
@@ -229,6 +239,7 @@ export function TabbedMembersView({ anchorId }) {
     <TabbedPageSection
       id={anchorId}
       headline="Capability Member Management"
+      headlineChildren={headlineChildren}
       tabs={tabs}
       tabsContent={tabsContent}
       header={header}

--- a/src/src/pages/rbac/index.tsx
+++ b/src/src/pages/rbac/index.tsx
@@ -1,8 +1,15 @@
-import React from "react";
-import { Check } from "lucide-react";
-import { usePermissionMatrix } from "@/state/remote/queries/rbac";
+import React, { useContext, useEffect, useState } from "react";
+import { Check, Save } from "lucide-react";
+import {
+    usePermissionMatrix,
+    useSetRolePermissions,
+} from "@/state/remote/queries/rbac";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SectionLabel } from "@/components/ui/SectionLabel";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import PreAppContext from "@/preAppContext";
+import { useToast } from "@/context/ToastContext";
 
 type RbacRoleDTO = {
     id: string;
@@ -32,16 +39,82 @@ type PermissionMatrixResponse = {
 
 export default function PermissionMatrixPage() {
     const { data, isFetching, isFetched } = usePermissionMatrix();
-    const matrix = data as PermissionMatrixResponse | undefined;
+    const { mutate: setRolePermissions } = useSetRolePermissions();
+    const { isCloudEngineerEnabled } = useContext(PreAppContext);
+    const toast = useToast();
 
+    const matrix = data as PermissionMatrixResponse | undefined;
     const roles: RbacRoleDTO[] = matrix?.roles ?? [];
     const permissions: PermissionDto[] = matrix?.permissions ?? [];
     const grants: PermissionMatrixGrantDto[] = matrix?.grants ?? [];
 
-    // Build a lookup set: "roleId|namespace|permission" → true
-    const grantSet = new Set<string>(
-        grants.map((g) => `${g.roleId}|${g.namespace}|${g.permission}`),
+    // Local draft state: "roleId|ns|perm" → boolean
+    const [localGrantSet, setLocalGrantSet] = useState<Record<string, boolean>>(
+        {},
     );
+    // Baseline that tracks what's persisted on the server (used for dirty-checking)
+    const [savedGrantSet, setSavedGrantSet] = useState<Record<string, boolean>>(
+        {},
+    );
+    // Which role is currently being saved
+    const [savingRoleId, setSavingRoleId] = useState<string | null>(null);
+
+    // Initialise both states once when data first arrives
+    useEffect(() => {
+        if (!isFetched) return;
+        const map: Record<string, boolean> = {};
+        grants.forEach((g) => {
+            map[`${g.roleId}|${g.namespace}|${g.permission}`] = true;
+        });
+        setLocalGrantSet(map);
+        setSavedGrantSet(map);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isFetched]);
+
+    // Original grant set for dirty checking
+    const isDirty = (roleId: string) =>
+        permissions.some((p) => {
+            const key = `${roleId}|${p.namespace}|${p.name}`;
+            return (localGrantSet[key] ?? false) !== (savedGrantSet[key] ?? false);
+        });
+
+    const handleToggle = (roleId: string, namespace: string, name: string) => {
+        const key = `${roleId}|${namespace}|${name}`;
+        setLocalGrantSet((prev: Record<string, boolean>) => ({
+            ...prev,
+            [key]: !(prev[key] ?? false),
+        }));
+    };
+
+    const handleSave = (roleId: string) => {
+        setSavingRoleId(roleId);
+        const permsToSave = permissions
+            .filter((p) => localGrantSet[`${roleId}|${p.namespace}|${p.name}`])
+            .map((p) => ({ namespace: p.namespace, name: p.name }));
+        setRolePermissions(
+            { roleId, permissions: permsToSave },
+            {
+                onSuccess: () => {
+                    // Advance the saved baseline to match what was just persisted,
+                    // so dirty-checking is correct without needing a refetch.
+                    setSavedGrantSet((prev: Record<string, boolean>) => {
+                        const updated = { ...prev };
+                        permissions.forEach((p) => {
+                            const key = `${roleId}|${p.namespace}|${p.name}`;
+                            updated[key] = localGrantSet[key] ?? false;
+                        });
+                        return updated;
+                    });
+                    toast.success("Permissions saved.");
+                    setSavingRoleId(null);
+                },
+                onError: () => {
+                    toast.error("Failed to save permissions.");
+                    setSavingRoleId(null);
+                },
+            },
+        );
+    };
 
     // Group permissions by namespace
     const namespaces = Array.from(
@@ -57,7 +130,7 @@ export default function PermissionMatrixPage() {
         <div className="px-5 md:px-8 py-6 max-w-[1400px] mx-auto">
             <div className="mb-6">
                 <div className="font-mono text-[11px] font-semibold tracking-[0.15em] uppercase text-[#0e7cc1] dark:text-[#60a5fa] mb-1">
-          // RBAC
+                    // RBAC
                 </div>
                 <h1 className="text-[1.6rem] font-bold text-[#002b45] dark:text-[#e2e8f0]">
                     Permission Matrix
@@ -65,6 +138,11 @@ export default function PermissionMatrixPage() {
                 <p className="mt-1 text-[13px] text-[#6b7280] dark:text-slate-400">
                     An overview of which permissions are granted to each role in the
                     system.
+                    {isCloudEngineerEnabled && (
+                        <span className="ml-1 text-amber-600 dark:text-amber-400">
+                            Toggle switches to edit, then save per column.
+                        </span>
+                    )}
                 </p>
             </div>
 
@@ -91,15 +169,33 @@ export default function PermissionMatrixPage() {
                                     <th className="sticky left-0 z-10 bg-white dark:bg-[#1e293b] px-4 py-3 text-left font-mono text-[11px] text-[#afafaf] dark:text-slate-500 min-w-[220px] border-r border-[#eeeeee] dark:border-[#1e2d3d]">
                                         Permission
                                     </th>
-                                    {roles.map((role) => (
-                                        <th
-                                            key={role.id}
-                                            title={role.description ?? role.name}
-                                            className="px-3 py-3 text-center font-mono text-[11px] text-[#002b45] dark:text-[#e2e8f0] whitespace-nowrap min-w-[120px]"
-                                        >
-                                            {role.name}
-                                        </th>
-                                    ))}
+                                    {roles.map((role) => {
+                                        const dirty = isDirty(role.id);
+                                        const saving = savingRoleId === role.id;
+                                        return (
+                                            <th
+                                                key={role.id}
+                                                title={role.description ?? role.name}
+                                                className="px-3 py-2 text-center font-mono text-[11px] text-[#002b45] dark:text-[#e2e8f0] whitespace-nowrap min-w-[120px]"
+                                            >
+                                                <div className="flex flex-col items-center gap-1.5">
+                                                    <span>{role.name}</span>
+                                                    {isCloudEngineerEnabled && (
+                                                        <Button
+                                                            size="sm"
+                                                            variant="action"
+                                                            onClick={() => handleSave(role.id)}
+                                                            disabled={!dirty || saving}
+                                                            className="h-6 px-2 text-[10px]"
+                                                        >
+                                                            <Save size={10} />
+                                                            {saving ? "Saving…" : "Save"}
+                                                        </Button>
+                                                    )}
+                                                </div>
+                                            </th>
+                                        );
+                                    })}
                                 </tr>
                             </thead>
                             <tbody>
@@ -134,21 +230,33 @@ export default function PermissionMatrixPage() {
                                                     )}
                                                 </td>
                                                 {roles.map((role) => {
-                                                    const hasGrant = grantSet.has(
-                                                        `${role.id}|${perm.namespace}|${perm.name}`,
-                                                    );
+                                                    const key = `${role.id}|${perm.namespace}|${perm.name}`;
+                                                    const checked = localGrantSet[key] ?? false;
+                                                    const saving = savingRoleId === role.id;
                                                     return (
-                                                        <td
-                                                            key={role.id}
-                                                            className="px-3 py-2 text-center"
-                                                        >
-                                                            {hasGrant && (
-                                                                <Check
-                                                                    size={14}
-                                                                    strokeWidth={2.5}
-                                                                    className="inline text-[#0e7cc1] dark:text-[#60a5fa]"
-                                                                    aria-label="Granted"
+                                                        <td key={role.id} className="px-3 py-2 text-center">
+                                                            {isCloudEngineerEnabled ? (
+                                                                <Switch
+                                                                    checked={checked}
+                                                                    onCheckedChange={() =>
+                                                                        handleToggle(
+                                                                            role.id,
+                                                                            perm.namespace,
+                                                                            perm.name,
+                                                                        )
+                                                                    }
+                                                                    disabled={saving}
+                                                                    aria-label={`${perm.name} for ${role.name}`}
                                                                 />
+                                                            ) : (
+                                                                checked && (
+                                                                    <Check
+                                                                        size={14}
+                                                                        strokeWidth={2.5}
+                                                                        className="inline text-[#0e7cc1] dark:text-[#60a5fa]"
+                                                                        aria-label="Granted"
+                                                                    />
+                                                                )
                                                             )}
                                                         </td>
                                                     );

--- a/src/src/pages/rbac/index.tsx
+++ b/src/src/pages/rbac/index.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { Check } from "lucide-react";
+import { usePermissionMatrix } from "@/state/remote/queries/rbac";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SectionLabel } from "@/components/ui/SectionLabel";
+
+type RbacRoleDTO = {
+    id: string;
+    name: string;
+    description?: string;
+    type?: string;
+};
+
+type PermissionDto = {
+    namespace: string;
+    name: string;
+    description?: string;
+    accessType?: string;
+};
+
+type PermissionMatrixGrantDto = {
+    roleId: string;
+    namespace: string;
+    permission: string;
+};
+
+type PermissionMatrixResponse = {
+    roles: RbacRoleDTO[];
+    permissions: PermissionDto[];
+    grants: PermissionMatrixGrantDto[];
+};
+
+export default function PermissionMatrixPage() {
+    const { data, isFetching, isFetched } = usePermissionMatrix();
+    const matrix = data as PermissionMatrixResponse | undefined;
+
+    const roles: RbacRoleDTO[] = matrix?.roles ?? [];
+    const permissions: PermissionDto[] = matrix?.permissions ?? [];
+    const grants: PermissionMatrixGrantDto[] = matrix?.grants ?? [];
+
+    // Build a lookup set: "roleId|namespace|permission" → true
+    const grantSet = new Set<string>(
+        grants.map((g) => `${g.roleId}|${g.namespace}|${g.permission}`),
+    );
+
+    // Group permissions by namespace
+    const namespaces = Array.from(
+        new Set(permissions.map((p) => p.namespace)),
+    ).sort();
+
+    const permissionsByNamespace: Record<string, PermissionDto[]> = {};
+    for (const ns of namespaces) {
+        permissionsByNamespace[ns] = permissions.filter((p) => p.namespace === ns);
+    }
+
+    return (
+        <div className="px-5 md:px-8 py-6 max-w-[1400px] mx-auto">
+            <div className="mb-6">
+                <div className="font-mono text-[11px] font-semibold tracking-[0.15em] uppercase text-[#0e7cc1] dark:text-[#60a5fa] mb-1">
+          // RBAC
+                </div>
+                <h1 className="text-[1.6rem] font-bold text-[#002b45] dark:text-[#e2e8f0]">
+                    Permission Matrix
+                </h1>
+                <p className="mt-1 text-[13px] text-[#6b7280] dark:text-slate-400">
+                    An overview of which permissions are granted to each role in the
+                    system.
+                </p>
+            </div>
+
+            {isFetching && !isFetched && (
+                <div className="space-y-3">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                        <Skeleton key={i} className="h-8 w-full rounded" />
+                    ))}
+                </div>
+            )}
+
+            {isFetched && roles.length === 0 && (
+                <p className="text-[13px] text-muted font-mono">
+                    No permission matrix data available.
+                </p>
+            )}
+
+            {isFetched && roles.length > 0 && (
+                <div className="bg-white dark:bg-[#1e293b] border border-[#d9dcde] dark:border-[#334155] rounded-[8px] overflow-hidden">
+                    <div className="overflow-x-auto">
+                        <table className="w-full border-collapse text-[12px]">
+                            <thead>
+                                <tr className="border-b border-[#eeeeee] dark:border-[#1e2d3d]">
+                                    <th className="sticky left-0 z-10 bg-white dark:bg-[#1e293b] px-4 py-3 text-left font-mono text-[11px] text-[#afafaf] dark:text-slate-500 min-w-[220px] border-r border-[#eeeeee] dark:border-[#1e2d3d]">
+                                        Permission
+                                    </th>
+                                    {roles.map((role) => (
+                                        <th
+                                            key={role.id}
+                                            title={role.description ?? role.name}
+                                            className="px-3 py-3 text-center font-mono text-[11px] text-[#002b45] dark:text-[#e2e8f0] whitespace-nowrap min-w-[120px]"
+                                        >
+                                            {role.name}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {namespaces.map((ns) => (
+                                    <React.Fragment key={ns}>
+                                        {/* Namespace header row */}
+                                        <tr className="bg-[#f8f9fa] dark:bg-[#0f172a]">
+                                            <td
+                                                colSpan={roles.length + 1}
+                                                className="sticky left-0 px-4 py-1.5"
+                                            >
+                                                <SectionLabel>{ns}</SectionLabel>
+                                            </td>
+                                        </tr>
+                                        {/* Permission rows */}
+                                        {permissionsByNamespace[ns].map((perm) => (
+                                            <tr
+                                                key={`${perm.namespace}|${perm.name}`}
+                                                className="border-t border-[#eeeeee] dark:border-[#1e2d3d] hover:bg-[#f8f9fa] dark:hover:bg-[#0f172a]/50"
+                                            >
+                                                <td className="sticky left-0 z-10 bg-white dark:bg-[#1e293b] hover:bg-[#f8f9fa] dark:hover:bg-[#0f172a]/50 px-4 py-2 border-r border-[#eeeeee] dark:border-[#1e2d3d]">
+                                                    <span
+                                                        className="font-mono text-[11px] text-[#002b45] dark:text-[#e2e8f0]"
+                                                        title={perm.description}
+                                                    >
+                                                        {perm.name}
+                                                    </span>
+                                                    {perm.accessType && (
+                                                        <span className="ml-2 inline-flex items-center rounded-full border border-[#d9dcde] dark:border-[#334155] px-1.5 py-0 font-mono text-[10px] text-[#afafaf] dark:text-slate-500">
+                                                            {perm.accessType}
+                                                        </span>
+                                                    )}
+                                                </td>
+                                                {roles.map((role) => {
+                                                    const hasGrant = grantSet.has(
+                                                        `${role.id}|${perm.namespace}|${perm.name}`,
+                                                    );
+                                                    return (
+                                                        <td
+                                                            key={role.id}
+                                                            className="px-3 py-2 text-center"
+                                                        >
+                                                            {hasGrant && (
+                                                                <Check
+                                                                    size={14}
+                                                                    strokeWidth={2.5}
+                                                                    className="inline text-[#0e7cc1] dark:text-[#60a5fa]"
+                                                                    aria-label="Granted"
+                                                                />
+                                                            )}
+                                                        </td>
+                                                    );
+                                                })}
+                                            </tr>
+                                        ))}
+                                    </React.Fragment>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/src/state/remote/queries/rbac.ts
+++ b/src/src/state/remote/queries/rbac.ts
@@ -33,6 +33,12 @@ export const useAllPermissions = createSsuQuery({
   authMode: true,
 });
 
+export const usePermissionMatrix = createSsuQuery({
+  queryKey: ["rbac", "permission-matrix"],
+  urlSegments: ["rbac/permission-matrix"],
+  authMode: true,
+});
+
 export const useRolePermissions = createSsuParamQuery<string>({
   queryKey: (roleId) => ["rbac", "role-permissions", roleId],
   urlSegments: (roleId) => ["rbac", "permission", "role", roleId],

--- a/src/src/state/remote/queries/rbac.ts
+++ b/src/src/state/remote/queries/rbac.ts
@@ -39,6 +39,16 @@ export const usePermissionMatrix = createSsuQuery({
   authMode: true,
 });
 
+export const useSetRolePermissions = createSsuMutation<{
+  roleId: string;
+  permissions: Array<{ namespace: string; name: string }>;
+}>({
+  method: "PUT",
+  urlSegments: (data) => ["rbac", "permission-matrix", "role", data.roleId],
+  payload: (data) => ({ permissions: data.permissions }),
+  authMode: true,
+});
+
 export const useRolePermissions = createSsuParamQuery<string>({
   queryKey: (roleId) => ["rbac", "role-permissions", roleId],
   urlSegments: (roleId) => ["rbac", "permission", "role", roleId],


### PR DESCRIPTION
🌟 Changes:
- Add menu point for viewing permission matrix
- Add link in membership link to permission matrix
- Permission matrix page shows permissions for our user roles
- As a cloud engineer, we can edit the permissions

🎶Notes:
- Cloudengineering permissions to edit are not manged by the RBAC system currently
- Does not look too nice on mobile screens (horizontal scroll), but tables like this rarely will without much work. Not worth it I think

❗Be aware:
- The current version does not show all roles, but that is an API issue, and not a frontend issue

🤖 Definitely AI assisted

🖼️ Screenshots:
<img width="1122" height="845" alt="image" src="https://github.com/user-attachments/assets/38a9a3e1-e77f-448c-9bd2-5ebd3a8ab673" />
<img width="1140" height="852" alt="image" src="https://github.com/user-attachments/assets/1234b73c-72df-4422-8791-228569324965" />
