### PR TITLE
tabulate kafka clusters

### DIFF
--- a/src/src/pages/capabilities/KafkaCluster/index.jsx
+++ b/src/src/pages/capabilities/KafkaCluster/index.jsx
@@ -10,7 +10,6 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import PageSection from "@/components/PageSection";
 import NewTopicDialog from "./NewTopicDialog";
 import { useState } from "react";
 import { useContext } from "react";
@@ -91,15 +90,15 @@ export default function KafkaCluster({ anchorId, cluster, capabilityId }) {
   );
 
   return (
-    <PageSection
-      id={anchorId}
-      headline="Kafka"
-      headlineChildren={
-        <span className="font-mono text-[10px] font-semibold tracking-[0.04em] bg-[rgba(237,136,0,0.1)] text-[#ed8800] px-2 py-[2px] rounded-full ml-2">
+    <div id={anchorId}>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-sm font-semibold text-[#002b45] dark:text-[#e2e8f0]">
+          Kafka
+        </span>
+        <span className="font-mono text-[10px] font-semibold tracking-[0.04em] bg-[rgba(237,136,0,0.1)] text-[#ed8800] px-2 py-[2px] rounded-full">
           {cluster.name}
         </span>
-      }
-    >
+      </div>
       {cluster.description && (
         <p className="text-[13px] text-[#666666] dark:text-slate-400 leading-[1.6] mb-3 whitespace-pre-wrap">
           {cluster.description}
@@ -327,6 +326,6 @@ export default function KafkaCluster({ anchorId, cluster, capabilityId }) {
           </TrackedButton>
         </div>
       )}
-    </PageSection>
+    </div>
   );
 }

--- a/src/src/pages/capabilities/KafkaCluster/index.jsx
+++ b/src/src/pages/capabilities/KafkaCluster/index.jsx
@@ -91,20 +91,6 @@ export default function KafkaCluster({ anchorId, cluster, capabilityId }) {
 
   return (
     <div id={anchorId}>
-      <div className="flex items-center gap-2 mb-3">
-        <span className="text-sm font-semibold text-[#002b45] dark:text-[#e2e8f0]">
-          Kafka
-        </span>
-        <span className="font-mono text-[10px] font-semibold tracking-[0.04em] bg-[rgba(237,136,0,0.1)] text-[#ed8800] px-2 py-[2px] rounded-full">
-          {cluster.name}
-        </span>
-      </div>
-      {cluster.description && (
-        <p className="text-[13px] text-[#666666] dark:text-slate-400 leading-[1.6] mb-3 whitespace-pre-wrap">
-          {cluster.description}
-        </p>
-      )}
-
       <Dialog
         open={showAccess}
         onOpenChange={(o) => !o && setShowAccess(false)}
@@ -294,14 +280,16 @@ export default function KafkaCluster({ anchorId, cluster, capabilityId }) {
         </div>
       )}
 
-      <TopicList
-        name="Public Topics"
-        topics={publicTopics}
-        clusterId={cluster.id}
-        selectedTopic={selectedKafkaTopic}
-        onTopicClicked={handleTopicClicked}
-        schemas={schemas}
-      />
+      {hasWriteAccess && (
+        <TopicList
+          name="Public Topics"
+          topics={publicTopics}
+          clusterId={cluster.id}
+          selectedTopic={selectedKafkaTopic}
+          onTopicClicked={handleTopicClicked}
+          schemas={schemas}
+        />
+      )}
 
       {hasWriteAccess && (
         <TopicList
@@ -315,15 +303,21 @@ export default function KafkaCluster({ anchorId, cluster, capabilityId }) {
       )}
 
       {canRequestAccess && (
-        <div className="flex gap-2 flex-wrap items-center mt-3">
-          <TrackedButton
-            trackName="KafkaCluster-RequestClusterAccess"
-            size="small"
-            submitting={isRequestingAccess}
-            onClick={handleRequestAccess}
-          >
-            Request Access
-          </TrackedButton>
+        <div className="flex flex-col gap-2 mt-3">
+          <p className="text-[13px] text-[#666666] dark:text-slate-400 leading-[1.6]">
+            You don&apos;t currently have access to this Kafka cluster. Request
+            access to view topics and connect to the cluster.
+          </p>
+          <div>
+            <TrackedButton
+              trackName="KafkaCluster-RequestClusterAccess"
+              size="small"
+              submitting={isRequestingAccess}
+              onClick={handleRequestAccess}
+            >
+              Request Access
+            </TrackedButton>
+          </div>
         </div>
       )}
     </div>

--- a/src/src/pages/capabilities/details.jsx
+++ b/src/src/pages/capabilities/details.jsx
@@ -244,7 +244,7 @@ function CapabilityDetailsPageContent() {
                 id="kafka"
                 headline="Kafka Clusters"
                 tabs={Object.fromEntries(
-                  (kafkaClusters || []).map((cluster, i) => [String(i), cluster.name]),
+                  (kafkaClusters || []).map((cluster, i) => [String(i), `${cluster.name} (${(cluster.topics || []).length})`]),
                 )}
                 tabsContent={Object.fromEntries(
                   (kafkaClusters || []).map((cluster, i) => [
@@ -308,8 +308,8 @@ function CapabilityDetailsPageContent() {
                   key={href}
                   href={href}
                   className={`block pl-3.5 pr-4 py-[0.3rem] font-mono text-[11px] no-underline tracking-[0.03em] transition-colors border-l-2 ${isActive
-                      ? "text-[#0e7cc1] dark:text-[#60a5fa] border-[#0e7cc1] dark:border-[#60a5fa]"
-                      : "text-[#666666] dark:text-slate-400 hover:text-[#0e7cc1] dark:hover:text-[#60a5fa] hover:bg-[#f2f2f2] dark:hover:bg-slate-700 border-transparent"
+                    ? "text-[#0e7cc1] dark:text-[#60a5fa] border-[#0e7cc1] dark:border-[#60a5fa]"
+                    : "text-[#666666] dark:text-slate-400 hover:text-[#0e7cc1] dark:hover:text-[#60a5fa] hover:bg-[#f2f2f2] dark:hover:bg-slate-700 border-transparent"
                     }`}
                 >
                   {label}

--- a/src/src/pages/capabilities/details.jsx
+++ b/src/src/pages/capabilities/details.jsx
@@ -10,7 +10,7 @@ import Costs from "./costs";
 import AwsResources from "./resources/aws";
 import AzureResources from "./resources/azure";
 import KafkaCluster from "./KafkaCluster";
-import PageSection from "@/components/PageSection";
+import PageSection, { TabbedPageSection } from "@/components/PageSection";
 import { Text } from "@/components/ui/Text";
 import {
   SkeletonCapabilityHeader,
@@ -235,34 +235,38 @@ function CapabilityDetailsPageContent() {
             <AzureResources anchorId="azure-resources" />
           </div>
 
-          {!awsAccount && (
-            <div
-              className="animate-section-enter"
-              style={{ animationDelay: "340ms" }}
-            >
-              <PageSection id="kafka" headline="Kafka Clusters">
-                <Text>
-                  No AWS account is linked to this capability. Please link an
-                  AWS account to view Kafka clusters.
-                </Text>
-              </PageSection>
-            </div>
-          )}
           <div
             className="animate-section-enter"
             style={{ animationDelay: "340ms" }}
           >
-            <section id="kafka">
-              {awsAccount !== undefined &&
-                awsAccount &&
-                (kafkaClusters || []).map((cluster) => (
-                  <KafkaCluster
-                    key={cluster.id}
-                    cluster={cluster}
-                    capabilityId={id}
-                  />
-                ))}
-            </section>
+            {awsAccount && (kafkaClusters || []).length > 1 ? (
+              <TabbedPageSection
+                id="kafka"
+                headline="Kafka Clusters"
+                tabs={Object.fromEntries(
+                  (kafkaClusters || []).map((cluster, i) => [String(i), cluster.name]),
+                )}
+                tabsContent={Object.fromEntries(
+                  (kafkaClusters || []).map((cluster, i) => [
+                    String(i),
+                    <KafkaCluster key={cluster.id} cluster={cluster} capabilityId={id} />,
+                  ]),
+                )}
+              />
+            ) : (
+              <PageSection id="kafka" headline="Kafka Clusters">
+                {!awsAccount && (
+                  <Text>
+                    No AWS account is linked to this capability. Please link an
+                    AWS account to view Kafka clusters.
+                  </Text>
+                )}
+                {awsAccount &&
+                  (kafkaClusters || []).map((cluster) => (
+                    <KafkaCluster key={cluster.id} cluster={cluster} capabilityId={id} />
+                  ))}
+              </PageSection>
+            )}
           </div>
 
           {showCosts && awsAccount !== undefined && (


### PR DESCRIPTION
❗  Update:

<img width="3360" height="363" alt="image" src="https://github.com/user-attachments/assets/169c290c-37a9-4b2e-b0f0-73865f32ff03" />


🌟 Changes:
- For capability details; use a single section for all Kafka Clusters instead of one section per cluster (this is in line with the other elements)

🎶 Notes:
<img width="3362" height="224" alt="image" src="https://github.com/user-attachments/assets/24695d83-b153-4869-a09d-77ed5c2c3105" />
<img width="3362" height="374" alt="image" src="https://github.com/user-attachments/assets/2c4a0f41-8d0f-44d0-ad7d-686bf2ec477e" />


❓ Questions:
It feels bad, that we cannot request access to Kafka without an AWS account.
For the user this is not an important detail, and we should hide it away.