### PR TITLE
Fix: aws resource modal overflowing

### DIFF
--- a/src/src/context/ThemeContext.tsx
+++ b/src/src/context/ThemeContext.tsx
@@ -10,12 +10,26 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue>({
   theme: "system",
-  setTheme: () => {},
+  setTheme: () => { },
   isDark: false,
 });
 
 export function useTheme(): ThemeContextValue {
   return useContext(ThemeContext);
+}
+
+export function useMuiTableColors() {
+  const { isDark } = useContext(ThemeContext);
+  return {
+    bg: isDark ? "#1e293b" : "#ffffff",
+    bgMuted: isDark ? "#0f172a" : "#f2f2f2",
+    textPrimary: isDark ? "#e2e8f0" : "#002b45",
+    textBody: isDark ? "#e2e8f0" : "#4d4e4c",
+    textMuted: isDark ? "#64748b" : "#afafaf",
+    borderColor: isDark ? "#334155" : "#eeeeee",
+    inputBorder: isDark ? "#334155" : undefined,
+    inputText: isDark ? "#e2e8f0" : undefined,
+  };
 }
 
 function resolveIsDark(theme: Theme): boolean {

--- a/src/src/pages/capabilities/AwsResourceCount/index.jsx
+++ b/src/src/pages/capabilities/AwsResourceCount/index.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import awsLogo from "./aws-logo.svg";
 import AppContext from "@/AppContext";
 import styles from "./AwsCount.module.css";
@@ -11,11 +11,76 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
 import { Text } from "@/components/ui/Text";
 import { MaterialReactTable } from "material-react-table";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { useCapabilitiesAwsResources } from "@/state/remote/queries/platformdataapi";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useTheme, useMuiTableColors } from "@/context/ThemeContext";
+
+
+const USE_MOCK = true;
+
+const MOCK_DATA = new Map([
+  [
+    "cloudengineering-xxx",
+    [
+      { resourceId: "aws_rds_db_total", resourceCount: 3 },
+      { resourceId: "aws_s3_bucket_total", resourceCount: 12 },
+      { resourceId: "aws_ssm_parameter_total", resourceCount: 45 },
+      { resourceId: "aws_lambda_function_total", resourceCount: 7 },
+      { resourceId: "aws_ecs_cluster_total", resourceCount: 2 },
+      { resourceId: "aws_ec2_fleet_total", resourceCount: 1 },
+      { resourceId: "aws_iam_policy_total", resourceCount: 18 },
+      { resourceId: "aws_iam_role_total", resourceCount: 34 },
+      { resourceId: "aws_dynamo_table_total", resourceCount: 5 },
+      { resourceId: "aws_sqs_queue_total", resourceCount: 9 },
+      { resourceId: "aws_sns_topic_total", resourceCount: 4 },
+      { resourceId: "aws_cloudwatch_alarm_total", resourceCount: 22 },
+      { resourceId: "aws_cloudwatch_log_group_total", resourceCount: 31 },
+      { resourceId: "aws_secretsmanager_total", resourceCount: 6 },
+      { resourceId: "aws_kms_key_total", resourceCount: 8 },
+      { resourceId: "aws_vpc_total", resourceCount: 2 },
+      { resourceId: "aws_subnet_total", resourceCount: 6 },
+      { resourceId: "aws_security_group_total", resourceCount: 14 },
+      { resourceId: "aws_elasticache_cluster_total", resourceCount: 1 },
+      { resourceId: "aws_alb_total", resourceCount: 3 },
+      { resourceId: "aws_alb_target_group_total", resourceCount: 5 },
+      { resourceId: "aws_cloudfront_distribution_total", resourceCount: 2 },
+      { resourceId: "aws_route53_zone_total", resourceCount: 3 },
+      { resourceId: "aws_route53_record_total", resourceCount: 27 },
+      { resourceId: "aws_ecr_repository_total", resourceCount: 4 },
+      { resourceId: "aws_eks_cluster_total", resourceCount: 1 },
+      { resourceId: "aws_codepipeline_total", resourceCount: 3 },
+      { resourceId: "aws_codebuild_project_total", resourceCount: 5 },
+      { resourceId: "aws_stepfunctions_statemachine_total", resourceCount: 2 },
+      { resourceId: "aws_apigateway_rest_api_total", resourceCount: 4 },
+      { resourceId: "aws_cognito_user_pool_total", resourceCount: 1 },
+      { resourceId: "aws_wafv2_web_acl_total", resourceCount: 2 },
+    ],
+  ],
+]);
+
+function useMockResources() {
+  const get = (capabilityId) =>
+    MOCK_DATA.get(capabilityId) ?? MOCK_DATA.get("__default__");
+  return {
+    query: { isFetched: true, data: MOCK_DATA },
+    getAwsResourcesTotalCountForCapability: (id) =>
+      get(id).reduce((s, r) => s + r.resourceCount, 0),
+    getAwsResourceCountsForCapability: (id) => get(id),
+    getAwsResourceCountsForCapabilityAndType: (id, type) =>
+      get(id).filter((r) => r.resourceId.includes(type))
+        .reduce((s, r) => s + r.resourceCount, 0),
+  };
+}
+
+function useResources() {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return USE_MOCK ? useMockResources() : useCapabilitiesAwsResources();
+}
+
+
 
 export function InlineAwsCountSummary({ data }) {
   return (
@@ -35,7 +100,7 @@ export function DetailedAwsCountSummary({ capabilityId }) {
     query,
     getAwsResourcesTotalCountForCapability,
     getAwsResourceCountsForCapabilityAndType,
-  } = useCapabilitiesAwsResources();
+  } = useResources();
   const count = getAwsResourcesTotalCountForCapability(capabilityId);
 
   const interests = [
@@ -115,10 +180,22 @@ function AwsCountCard({ title, subtitle, count }) {
   );
 }
 
+function SortIcon({ direction }) {
+  if (!direction) return <span className="ml-1 opacity-30">↕</span>;
+  return <span className="ml-1">{direction === "asc" ? "↑" : "↓"}</span>;
+}
+
 function ResourcesWindow({ onCloseRequested, capabilityId }) {
-  const { getAwsResourceCountsForCapability } = useCapabilitiesAwsResources();
+  const { getAwsResourceCountsForCapability } = useResources();
   const counts = getAwsResourceCountsForCapability(capabilityId);
   const isMobile = useIsMobile();
+  const { isDark } = useTheme();
+  const { bg, bgMuted, textPrimary, textBody, borderColor } = useMuiTableColors();
+
+  const muiTheme = useMemo(
+    () => createTheme({ palette: { mode: isDark ? "dark" : "light" } }),
+    [isDark],
+  );
 
   const countsArray = [...counts].map((val) => ({
     name: val.resourceId,
@@ -130,30 +207,18 @@ function ResourcesWindow({ onCloseRequested, capabilityId }) {
       {
         accessorKey: "name",
         header: "Name",
-        Cell: ({ renderedCellValue }) => {
-          return (
-            <Text styledAs="action" as={"div"}>
-              {renderedCellValue}
-            </Text>
-          );
-        },
+        Cell: ({ renderedCellValue }) => (
+          <Text styledAs="action" as="div">{renderedCellValue}</Text>
+        ),
       },
       {
         accessorKey: "count",
         header: "Count",
-        Cell: ({ renderedCellValue }) => {
-          return (
-            <Text styledAs="action" as={"div"}>
-              {renderedCellValue}
-            </Text>
-          );
-        },
-        muiTableHeadCellProps: {
-          align: "center",
-        },
-        muiTableBodyCellProps: {
-          align: "center",
-        },
+        Cell: ({ renderedCellValue }) => (
+          <Text styledAs="action" as="div">{renderedCellValue}</Text>
+        ),
+        muiTableHeadCellProps: { align: "center" },
+        muiTableBodyCellProps: { align: "center" },
       },
     ],
     [],
@@ -165,52 +230,50 @@ function ResourcesWindow({ onCloseRequested, capabilityId }) {
         <DialogHeader>
           <DialogTitle>Complete list of resources in AWS</DialogTitle>
         </DialogHeader>
-        {isMobile ? (
-          <div className="divide-y divide-divider overflow-y-auto">
-            {countsArray.map((item) => (
-              <div key={item.name} className="flex items-center justify-between px-3 py-2.5">
-                <span className="text-sm text-primary">{item.name}</span>
-                <span className="text-sm font-medium text-primary tabular-nums">{item.count}</span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="overflow-y-auto flex-1">
-          <MaterialReactTable
-            columns={columns}
-            data={countsArray}
-            muiTableHeadCellProps={{
-              sx: {
-                fontWeight: "700",
-                fontSize: "16px",
-                fontFamily: "DFDS",
-                color: "#002b45",
-              },
-            }}
-            muiTableBodyCellProps={{
-              sx: {
-                fontWeight: "400",
-                fontSize: "16px",
-                fontFamily: "DFDS",
-                color: "#4d4e4c",
-                padding: "5px",
-              },
-            }}
-            muiTablePaperProps={{
-              elevation: 0,
-              sx: {
-                borderRadius: "0",
-              },
-            }}
-            enablePagination={false}
-            enableTopToolbar={false}
-            enableBottomToolbar={false}
-            enableColumnActions={false}
-            enableColumnFilters={false}
-          />
-          </div>
-        )}
-        <DialogFooter>
+        <div className="overflow-y-auto flex-1">
+          <ThemeProvider theme={muiTheme}>
+            <MaterialReactTable
+              columns={columns}
+              data={countsArray}
+              muiTableHeadCellProps={{
+                sx: {
+                  fontWeight: "700",
+                  fontSize: "16px",
+                  fontFamily: "DFDS",
+                  color: textPrimary,
+                  backgroundColor: bg,
+                  borderBottom: `1px solid ${borderColor}`,
+                },
+              }}
+              muiTableBodyCellProps={{
+                sx: {
+                  fontWeight: "400",
+                  fontSize: "16px",
+                  fontFamily: "DFDS",
+                  color: textBody,
+                  backgroundColor: bg,
+                  padding: "5px",
+                  borderBottom: `1px solid ${borderColor}`,
+                },
+              }}
+              muiTableBodyRowProps={{
+                sx: {
+                  "&:hover td": { backgroundColor: bgMuted },
+                },
+              }}
+              muiTablePaperProps={{
+                elevation: 0,
+                sx: { borderRadius: "0", backgroundColor: bg },
+              }}
+              enablePagination={false}
+              enableTopToolbar={false}
+              enableBottomToolbar={false}
+              enableColumnActions={false}
+              enableColumnFilters={false}
+            />
+          </ThemeProvider>
+        </div>
+        <DialogFooter className="mt-2">
           <Button variant="outline" onClick={onCloseRequested}>
             Close
           </Button>

--- a/src/src/pages/capabilities/AwsResourceCount/index.jsx
+++ b/src/src/pages/capabilities/AwsResourceCount/index.jsx
@@ -19,7 +19,7 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 import { useTheme, useMuiTableColors } from "@/context/ThemeContext";
 
 
-const USE_MOCK = true;
+const USE_MOCK = false;
 
 const MOCK_DATA = new Map([
   [

--- a/src/src/pages/capabilities/AwsResourceCount/index.jsx
+++ b/src/src/pages/capabilities/AwsResourceCount/index.jsx
@@ -2,6 +2,7 @@ import React, { useContext, useMemo } from "react";
 import awsLogo from "./aws-logo.svg";
 import AppContext from "@/AppContext";
 import styles from "./AwsCount.module.css";
+import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -160,12 +161,12 @@ function ResourcesWindow({ onCloseRequested, capabilityId }) {
 
   return (
     <Dialog open={true} onOpenChange={(o) => !o && onCloseRequested()}>
-      <DialogContent className={isMobile ? "max-w-[95%]" : "max-w-[60%]"}>
+      <DialogContent className={cn(isMobile ? "max-w-[95%]" : "max-w-[60%]", "flex flex-col max-h-[90vh]")}>
         <DialogHeader>
           <DialogTitle>Complete list of resources in AWS</DialogTitle>
         </DialogHeader>
         {isMobile ? (
-          <div className="divide-y divide-divider max-h-[60vh] overflow-y-auto">
+          <div className="divide-y divide-divider overflow-y-auto">
             {countsArray.map((item) => (
               <div key={item.name} className="flex items-center justify-between px-3 py-2.5">
                 <span className="text-sm text-primary">{item.name}</span>
@@ -174,6 +175,7 @@ function ResourcesWindow({ onCloseRequested, capabilityId }) {
             ))}
           </div>
         ) : (
+          <div className="overflow-y-auto flex-1">
           <MaterialReactTable
             columns={columns}
             data={countsArray}
@@ -206,6 +208,7 @@ function ResourcesWindow({ onCloseRequested, capabilityId }) {
             enableColumnActions={false}
             enableColumnFilters={false}
           />
+          </div>
         )}
         <DialogFooter>
           <Button variant="outline" onClick={onCloseRequested}>

--- a/src/src/pages/capabilities/Capabilities.jsx
+++ b/src/src/pages/capabilities/Capabilities.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState, useMemo } from "react";
-import { useTheme } from "@/context/ThemeContext";
+import { useTheme, useMuiTableColors } from "@/context/ThemeContext";
 import { Text } from "@/components/ui/Text";
 import { Link } from "react-router-dom";
 import { ChevronRight, AlertCircle, ArrowUp, ArrowDown } from "lucide-react";
@@ -128,13 +128,13 @@ function CapabilityCardList({ filteredCapabilities, truncateString }) {
 
   const visibleCapabilities = globalFilter
     ? filteredCapabilities.filter((cap) => {
-        const q = globalFilter.toLowerCase();
-        return (
-          cap.name?.toLowerCase().includes(q) ||
-          cap.description?.toLowerCase().includes(q) ||
-          cap.awsAccountId?.toLowerCase().includes(q)
-        );
-      })
+      const q = globalFilter.toLowerCase();
+      return (
+        cap.name?.toLowerCase().includes(q) ||
+        cap.description?.toLowerCase().includes(q) ||
+        cap.awsAccountId?.toLowerCase().includes(q)
+      );
+    })
     : filteredCapabilities;
 
   const sortedCapabilities = useMemo(() => {
@@ -267,15 +267,9 @@ function CapabilitiesTable({ columns, filteredCapabilities }) {
   const { globalFilter, setGlobalFilter } = useContext(AppContext);
   const { isDark } = useTheme();
 
-  const bg = isDark ? "#1e293b" : "#ffffff";
-  const bgMuted = isDark ? "#0f172a" : "#f2f2f2";
+  const { bg, bgMuted, textPrimary, textMuted, borderColor, inputBorder, inputText } = useMuiTableColors();
   const bgDeleted = isDark ? "#3b1a1a" : "#dd8888";
   const bgDeletedHover = isDark ? "#4a2020" : "rgba(187, 221, 243, 0.1)";
-  const textPrimary = isDark ? "#e2e8f0" : "#002b45";
-  const textMuted = isDark ? "#64748b" : "#afafaf";
-  const borderColor = isDark ? "#334155" : "#eeeeee";
-  const inputBorder = isDark ? "#334155" : undefined;
-  const inputText = isDark ? "#e2e8f0" : undefined;
 
   return (
     <MaterialReactTable
@@ -613,11 +607,11 @@ export default function CapabilitiesList() {
             sortingFn: (rowA, rowB) => {
               const ac =
                 JSON.parse(rowA.original.jsonMetadata ?? "{}")[
-                  "dfds.cost.centre"
+                "dfds.cost.centre"
                 ] ?? "";
               const bc =
                 JSON.parse(rowB.original.jsonMetadata ?? "{}")[
-                  "dfds.cost.centre"
+                "dfds.cost.centre"
                 ] ?? "";
               return (
                 ac.localeCompare(bc) ||
@@ -749,13 +743,11 @@ export default function CapabilitiesList() {
   return (
     <>
       <PageSection
-        headline={`${showOnlyMyCapabilities ? "My" : "All"} Capabilities ${
-          isLoading
+        headline={`${showOnlyMyCapabilities ? "My" : "All"} Capabilities ${isLoading
             ? ""
-            : `(${(filteredCapabilities || []).length} / ${
-                (capabilities || []).length
-              })`
-        }`}
+            : `(${(filteredCapabilities || []).length} / ${(capabilities || []).length
+            })`
+          }`}
         headlineChildren={
           isLoading ? null : (
             <div className={styles.myCapabilitiesToggleContainer}>

--- a/src/src/pages/capabilities/criticality.jsx
+++ b/src/src/pages/capabilities/criticality.jsx
@@ -9,7 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { MaterialReactTable } from "material-react-table";
 import PageSection from "@/components/PageSection";
 import PreAppContext from "../../preAppContext";
-import { useTheme } from "@/context/ThemeContext";
+import { useTheme, useMuiTableColors } from "@/context/ThemeContext";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { PaginationControls } from "@/components/ui/PaginationControls";
@@ -70,14 +70,7 @@ export default function CapabilitiesCriticalityPage() {
     [isDark],
   );
 
-  const bg = isDark ? "#1e293b" : "#ffffff";
-  const bgMuted = isDark ? "#0f172a" : "#f2f2f2";
-  const textPrimary = isDark ? "#e2e8f0" : "#002b45";
-  const textBody = isDark ? "#e2e8f0" : "#4d4e4c";
-  const textMuted = isDark ? "#64748b" : "#afafaf";
-  const borderColor = isDark ? "#334155" : "#eeeeee";
-  const inputBorder = isDark ? "#334155" : undefined;
-  const inputText = isDark ? "#e2e8f0" : undefined;
+  const { bg, bgMuted, textPrimary, textBody, textMuted, borderColor, inputBorder, inputText } = useMuiTableColors();
 
   const navigate = useNavigate();
   const clickHandler = (id) => navigate(`/capabilities/${id}`);


### PR DESCRIPTION
🌟 Changes:
- Added limitations to the AWS Resource modal to prevent overflow
- Moved darkmode colours into a shared place for Material UI Tabels (as they don't respect the theming inherently)

🎶 Notes:
- Added a mock flag, to allow testing this specifically for our `cloudengineering-xxx` capability. Currently toggled in `src/pages/capabilities/AwsResourceCount/index.jsx`

<img width="2042" height="1219" alt="image" src="https://github.com/user-attachments/assets/6bb67855-d6be-4937-be86-062eb31c562f" />
