### PR TITLE
Cost rendering

### DIFF
--- a/src/src/components/BasicCapabilityCost/index.jsx
+++ b/src/src/components/BasicCapabilityCost/index.jsx
@@ -10,45 +10,37 @@ import {
 } from "recharts";
 import React from "react";
 
-export function CapabilityCostSummary({ data }) {
-  const d1 = Math.min(...data.map((x) => x.pv)) * 0.95;
-  const d2 = Math.max(...data.map((x) => x.pv)) * 1.05;
-
+export function CapabilityCostSummary({ data, previousData }) {
   const has_data = data.length > 0;
 
-  const averageCost = Math.floor(
-    data.reduce((acc, x) => acc + x.pv, 0) / data.length,
-  );
+  const totalCost = has_data
+    ? data.reduce((acc, x) => acc + x.pv, 0)
+    : null;
 
-  let displayedCost = averageCost < 1 ? "<$1/d" : `$${averageCost}/d`;
+  const prevTotal =
+    previousData && previousData.length > 0
+      ? previousData.reduce((acc, x) => acc + x.pv, 0)
+      : null;
 
-  const domain = [d1, d2];
+  const trendPct =
+    totalCost != null && prevTotal != null && prevTotal > 0
+      ? ((totalCost - prevTotal) / prevTotal) * 100
+      : null;
+
+  const isLower = trendPct != null && trendPct < 0;
+  const trendClass = isLower ? styles.trendGood : styles.trendBad;
+
+  const displayedCost =
+    totalCost == null ? "No data" : totalCost < 1 ? "<$1" : `$${Math.floor(totalCost)}`;
+
   return (
-    <div className={styles.chartContainer}>
-      <div className={styles.costDataSummary}>
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={data}>
-            <XAxis dataKey="timestamp" hide />
-            <YAxis type="number" domain={domain} hide></YAxis>
-            <Tooltip content={CostTooltip} />
-            <CartesianGrid strokeDasharray="1" />
-            <Line
-              type="monotone"
-              dataKey="pv"
-              stroke="#014874"
-              strokeWidth={2}
-              dot={false}
-              isAnimationActive={false}
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-      <div className={styles.costDataSummaryCostContainer}>
-        <div className={styles.costDataSummaryCostAvg}>Average</div>
-        <div className={styles.costDataSummaryCost}>
-          {has_data ? displayedCost : "No data"}
-        </div>
-      </div>
+    <div className={styles.costInline}>
+      <span className={styles.costDataSummaryCost}>{displayedCost}</span>
+      {trendPct != null && (
+        <span className={`${styles.costTrend} ${trendClass}`}>
+          {isLower ? "↓" : "↑"} {Math.abs(Math.round(trendPct))}%
+        </span>
+      )}
     </div>
   );
 }
@@ -61,9 +53,26 @@ export function LargeCapabilityCostSummary({ data }) {
   return (
     <div className={styles.largeCostDataSummary}>
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
-          <XAxis hide />
-          <YAxis type="number" scale="linear" domain={domain} unit={"$"} />
+        <LineChart data={data} margin={{ top: 4, right: 16, bottom: 4, left: 16 }}>
+          <XAxis
+            dataKey="name"
+            tickFormatter={(val) =>
+              new Date(val).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+              })
+            }
+            tick={{ fontSize: 11 }}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            type="number"
+            scale="linear"
+            domain={domain}
+            tickFormatter={(val) => `$${val}`}
+            tick={{ fontSize: 11 }}
+            width={55}
+          />
           <Tooltip content={CostTooltip} />
           <CartesianGrid strokeDasharray="1 1" />
           <Line

--- a/src/src/components/BasicCapabilityCost/index.jsx
+++ b/src/src/components/BasicCapabilityCost/index.jsx
@@ -59,6 +59,20 @@ export function LargeCapabilityCostSummary({ data }) {
   const { isDark } = useTheme();
   const lineColor = isDark ? "#38bdf8" : "#055874";
 
+  // Pad data to always fill 30 days so the X-axis span is consistent.
+  // Missing leading days get pv: null (recharts skips nulls).
+  const paddedData = React.useMemo(() => {
+    const DAYS = 30;
+    if (data.length >= DAYS) return data;
+    const today = new Date();
+    const leading = Array.from({ length: DAYS - data.length }, (_, i) => {
+      const d = new Date(today);
+      d.setDate(today.getDate() - (DAYS - 1 - i));
+      return { name: d.toISOString().split("T")[0], pv: null };
+    });
+    return [...leading, ...data];
+  }, [data]);
+
   const d1 = Math.min(...data.map((x) => x.pv)) * 0.95;
   const d2 = Math.max(...data.map((x) => x.pv)) * 1.05;
 
@@ -66,7 +80,7 @@ export function LargeCapabilityCostSummary({ data }) {
   return (
     <div className={styles.largeCostDataSummary}>
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data} margin={{ top: 4, right: 16, bottom: 4, left: 16 }}>
+        <LineChart data={paddedData} margin={{ top: 4, right: 16, bottom: 4, left: 16 }}>
           <XAxis
             dataKey="name"
             tickFormatter={(val) =>

--- a/src/src/components/BasicCapabilityCost/index.jsx
+++ b/src/src/components/BasicCapabilityCost/index.jsx
@@ -11,13 +11,13 @@ import {
 import React from "react";
 import { useTheme } from "@/context/ThemeContext";
 
-export function CapabilityCostSummary({ data, previousData, previousDataIsFull = true }) {
-  const has_data = data.length > 0;
+export function CapabilityCostSummary({ data: current_data, previousData, previousDataIsFull = true }) {
+  const has_current_data = current_data.length > 0;
 
-  const totalCost = has_data
-    ? data.reduce((acc, x) => acc + x.pv, 0)
+  const currentTotal = has_current_data
+    ? current_data.reduce((acc, x) => acc + x.pv, 0)
     : null;
-  const avgCost = totalCost != null ? totalCost / data.length : null;
+  const avgCost = currentTotal != null ? currentTotal / current_data.length : null;
 
   const prevTotal =
     previousData && previousData.length > 0
@@ -34,7 +34,7 @@ export function CapabilityCostSummary({ data, previousData, previousDataIsFull =
   const trendClass = isLower ? styles.trendGood : styles.trendBad;
 
   const displayedCost =
-    totalCost == null ? "No data" : totalCost < 1 ? "<$1" : `$${Math.floor(totalCost)}`;
+    currentTotal == null ? "No data" : currentTotal < 1 ? "<$1" : `$${Math.floor(currentTotal)}`;
 
   return (
     <div className={styles.costInline}>

--- a/src/src/components/BasicCapabilityCost/index.jsx
+++ b/src/src/components/BasicCapabilityCost/index.jsx
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import React from "react";
+import { useTheme } from "@/context/ThemeContext";
 
 export function CapabilityCostSummary({ data, previousData }) {
   const has_data = data.length > 0;
@@ -46,6 +47,9 @@ export function CapabilityCostSummary({ data, previousData }) {
 }
 
 export function LargeCapabilityCostSummary({ data }) {
+  const { isDark } = useTheme();
+  const lineColor = isDark ? "#38bdf8" : "#055874";
+
   const d1 = Math.min(...data.map((x) => x.pv)) * 0.95;
   const d2 = Math.max(...data.map((x) => x.pv)) * 1.05;
 
@@ -78,7 +82,7 @@ export function LargeCapabilityCostSummary({ data }) {
           <Line
             type="monotone"
             dataKey="pv"
-            stroke="#055874"
+            stroke={lineColor}
             strokeWidth={2}
             dot={false}
             isAnimationActive={false}

--- a/src/src/components/BasicCapabilityCost/index.jsx
+++ b/src/src/components/BasicCapabilityCost/index.jsx
@@ -11,21 +11,23 @@ import {
 import React from "react";
 import { useTheme } from "@/context/ThemeContext";
 
-export function CapabilityCostSummary({ data, previousData }) {
+export function CapabilityCostSummary({ data, previousData, previousDataIsFull = true }) {
   const has_data = data.length > 0;
 
   const totalCost = has_data
     ? data.reduce((acc, x) => acc + x.pv, 0)
     : null;
+  const avgCost = totalCost != null ? totalCost / data.length : null;
 
   const prevTotal =
     previousData && previousData.length > 0
       ? previousData.reduce((acc, x) => acc + x.pv, 0)
       : null;
+  const prevAvg = prevTotal != null ? prevTotal / previousData.length : null;
 
   const trendPct =
-    totalCost != null && prevTotal != null && prevTotal > 0
-      ? ((totalCost - prevTotal) / prevTotal) * 100
+    avgCost != null && prevAvg != null && prevAvg > 0
+      ? ((avgCost - prevAvg) / prevAvg) * 100
       : null;
 
   const isLower = trendPct != null && trendPct < 0;
@@ -37,9 +39,16 @@ export function CapabilityCostSummary({ data, previousData }) {
   return (
     <div className={styles.costInline}>
       <span className={styles.costDataSummaryCost}>{displayedCost}</span>
-      {trendPct != null && (
-        <span className={`${styles.costTrend} ${trendClass}`}>
-          {isLower ? "↓" : "↑"} {Math.abs(Math.round(trendPct))}%
+      {trendPct != null ? (
+        <span
+          className={`${styles.costTrend} ${trendClass}`}
+          title={!previousDataIsFull ? "Approximate \u2014 less than 60 days of history available" : undefined}
+        >
+          {isLower ? "\u2193" : "\u2191"} {!previousDataIsFull ? "~" : ""}{Math.abs(Math.round(trendPct))}%
+        </span>
+      ) : (
+        <span className={`${styles.costTrend} ${styles.trendUnknown}`} title="Not enough history to calculate trend">
+          ?%
         </span>
       )}
     </div>

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -1,3 +1,10 @@
+.costInline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
 .chartContainer {
   display: flex;
   align-items: center;
@@ -9,6 +16,7 @@
   width: 150px;
   height: 35px;
 }
+
 .costDataSummaryCostContainer {
   display: flex;
   flex-direction: column;
@@ -25,9 +33,24 @@
 }
 
 .costDataSummaryCost {
-  color: #595959;
-  font-size: 11px;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
   text-align: center;
+}
+
+.costTrend {
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.trendGood {
+  color: #1a7f3c;
+}
+
+.trendBad {
+  color: #c0392b;
 }
 
 .largeCostDataSummary {

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -40,9 +40,16 @@
 }
 
 .costTrend {
+  display: inline-block;
+  min-width: 48px;
   font-size: 11px;
   font-weight: 600;
-  text-align: center;
+  text-align: left;
+}
+
+.trendUnknown {
+  color: #9ca3af;
+  font-weight: 400;
 }
 
 .trendGood {

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -33,8 +33,10 @@
 }
 
 .costDataSummaryCost {
+  display: inline-block;
+  min-width: 72px;
   font-size: 13px;
-  text-align: center;
+  text-align: right;
 }
 
 .costTrend {

--- a/src/src/components/BasicCapabilityCost/style.module.css
+++ b/src/src/components/BasicCapabilityCost/style.module.css
@@ -33,9 +33,7 @@
 }
 
 .costDataSummaryCost {
-  color: #ffffff;
   font-size: 13px;
-  font-weight: 600;
   text-align: center;
 }
 

--- a/src/src/pages/capabilities/Capabilities.jsx
+++ b/src/src/pages/capabilities/Capabilities.jsx
@@ -412,8 +412,8 @@ export default function CapabilitiesList() {
   useEffect(() => {
     if (isCapabilityFetched && capabilitiesData) {
       const capsWithCosts = capabilitiesData.map((cap) => {
-        const { current, previous } = getCostComparisonForCapability(cap.id);
-        return { ...cap, costs: current, previousCosts: previous };
+        const { current, previous, hasFullComparison } = getCostComparisonForCapability(cap.id);
+        return { ...cap, costs: current, previousCosts: previous, costsComparisonIsFull: hasFullComparison };
       });
       setCapabilities(capsWithCosts);
 
@@ -688,9 +688,10 @@ export default function CapabilitiesList() {
             Cell: ({ cell, row }) => {
               let data = cell.getValue() != null ? cell.getValue() : [];
               let previousData = row.original.previousCosts ?? [];
+              let previousDataIsFull = row.original.costsComparisonIsFull ?? true;
               return (
                 <div className={styles.costs}>
-                  <CapabilityCostSummary data={data} previousData={previousData} />
+                  <CapabilityCostSummary data={data} previousData={previousData} previousDataIsFull={previousDataIsFull} />
                 </div>
               );
             },

--- a/src/src/pages/capabilities/Capabilities.jsx
+++ b/src/src/pages/capabilities/Capabilities.jsx
@@ -400,7 +400,7 @@ export default function CapabilitiesList() {
   const { isCloudEngineerEnabled } = useContext(PreAppContext);
   const { isFetched: isCapabilityFetched, data: capabilitiesData } =
     useCapabilities();
-  const { query: costsQuery, getCostsForCapability } = useCapabilitiesCost();
+  const { query: costsQuery, getCostComparisonForCapability } = useCapabilitiesCost();
 
   const isMobile = useIsMobile();
   const [isLoading, setIsLoading] = useState(true);
@@ -411,10 +411,10 @@ export default function CapabilitiesList() {
 
   useEffect(() => {
     if (isCapabilityFetched && capabilitiesData) {
-      const capsWithCosts = capabilitiesData.map((cap) => ({
-        ...cap,
-        costs: getCostsForCapability(cap.id, 7),
-      }));
+      const capsWithCosts = capabilitiesData.map((cap) => {
+        const { current, previous } = getCostComparisonForCapability(cap.id);
+        return { ...cap, costs: current, previousCosts: previous };
+      });
       setCapabilities(capsWithCosts);
 
       const myCapabilities = capsWithCosts.filter((capability) => {
@@ -660,7 +660,7 @@ export default function CapabilitiesList() {
 
           {
             accessorFn: (row) => row.costs,
-            header: "Costs",
+            header: "Cost (last 30 days)",
             size: 150,
             enableColumnFilterModes: false,
             sortingFn: (rowA, rowB) => {
@@ -685,11 +685,12 @@ export default function CapabilitiesList() {
             muiTableBodyCellProps: {
               align: "right",
             },
-            Cell: ({ cell }) => {
+            Cell: ({ cell, row }) => {
               let data = cell.getValue() != null ? cell.getValue() : [];
+              let previousData = row.original.previousCosts ?? [];
               return (
                 <div className={styles.costs}>
-                  <CapabilityCostSummary data={data} />
+                  <CapabilityCostSummary data={data} previousData={previousData} />
                 </div>
               );
             },
@@ -744,9 +745,9 @@ export default function CapabilitiesList() {
     <>
       <PageSection
         headline={`${showOnlyMyCapabilities ? "My" : "All"} Capabilities ${isLoading
-            ? ""
-            : `(${(filteredCapabilities || []).length} / ${(capabilities || []).length
-            })`
+          ? ""
+          : `(${(filteredCapabilities || []).length} / ${(capabilities || []).length
+          })`
           }`}
         headlineChildren={
           isLoading ? null : (

--- a/src/src/pages/capabilities/SelectedCapabilityContext.jsx
+++ b/src/src/pages/capabilities/SelectedCapabilityContext.jsx
@@ -77,7 +77,7 @@ function SelectedCapabilityProvider({ children }) {
     useCapabilityMembersDetailed(details); // NEW
   const [isPendingDeletion, setPendingDeletion] = useState(null);
   const [isDeleted, setIsDeleted] = useState(null);
-  const [showCosts, setShowCosts] = useState(false);
+  const [showCosts, setShowCosts] = useState(true);
   const { isFetched: isClustersListFetched, data: clustersList } =
     useKafkaClustersAccessList(details); // NEW
   const { data: awsAccountDetails, isFetched: isLoadedAccount } =
@@ -603,10 +603,11 @@ function SelectedCapabilityProvider({ children }) {
 
   useEffect(() => {
     if (meData) {
-      let capabilityJoined =
+      const capabilityJoined =
         meData.capabilities.find((x) => x.id === capabilityId) !== undefined;
-      setShowCosts(capabilityJoined);
+      setShowCosts(capabilityJoined || import.meta.env.DEV);
     }
+    // Only hide once meData has confirmed non-membership; default (true) shows it immediately.
   }, [details, meData]);
 
   useEffect(() => {

--- a/src/src/pages/capabilities/SelectedCapabilityContext.jsx
+++ b/src/src/pages/capabilities/SelectedCapabilityContext.jsx
@@ -601,14 +601,16 @@ function SelectedCapabilityProvider({ children }) {
 
   //--------------------------------------------------------------------
 
+  /*
   useEffect(() => {
     if (meData) {
       const capabilityJoined =
         meData.capabilities.find((x) => x.id === capabilityId) !== undefined;
-      setShowCosts(capabilityJoined || import.meta.env.DEV);
+      setShowCosts(capabilityJoined);
     }
     // Only hide once meData has confirmed non-membership; default (true) shows it immediately.
   }, [details, meData]);
+  */
 
   useEffect(() => {
     if (isFetched && capability != null) {

--- a/src/src/pages/capabilities/costs/index.jsx
+++ b/src/src/pages/capabilities/costs/index.jsx
@@ -10,14 +10,17 @@ export default function Costs({ anchorId, costCentre }) {
   const { getCostComparisonForCapability } = useCapabilitiesCost();
   const { id } = useParams();
 
-  const { current, previous } = getCostComparisonForCapability(id);
+  const { current, previous, hasFullComparison } = getCostComparisonForCapability(id);
   const totalCost = current.reduce((acc, x) => acc + x.pv, 0);
   const previousTotal = previous.reduce((acc, x) => acc + x.pv, 0);
   const hasData = current.length > 0;
 
+  const avgCost = hasData ? totalCost / current.length : 0;
+  const previousAvg = previous.length > 0 ? previousTotal / previous.length : 0;
+
   const trendPct =
-    hasData && previous.length > 0 && previousTotal > 0
-      ? ((totalCost - previousTotal) / previousTotal) * 100
+    hasData && previous.length > 0 && previousAvg > 0
+      ? ((avgCost - previousAvg) / previousAvg) * 100
       : null;
   const isLower = trendPct != null && trendPct < 0;
 
@@ -28,13 +31,26 @@ export default function Costs({ anchorId, costCentre }) {
           {hasData ? `$${Math.floor(totalCost)}` : "No data"}
         </span>
         <span className="font-mono text-[11px] text-muted ml-2">total last 30 days</span>
-        {trendPct != null && (
-          <div
-            className="font-mono text-[12px] font-semibold mt-1"
-            style={{ color: isLower ? "#1a7f3c" : "#c0392b" }}
-          >
-            {isLower ? "↓" : "↑"} {Math.abs(Math.round(trendPct))}% vs previous 30 days
+        {trendPct != null ? (
+          <div className="mt-1">
+            <div
+              className="font-mono text-[12px] font-semibold"
+              style={{ color: isLower ? "#1a7f3c" : "#c0392b" }}
+            >
+              {isLower ? "\u2193" : "\u2191"} {!hasFullComparison ? "~" : ""}{Math.abs(Math.round(trendPct))}% vs previous {previous.length} days
+            </div>
+            <div className="font-mono text-[10px] text-muted mt-0.5">
+              {hasFullComparison
+                ? "Based on average daily cost over the prior 30-day period."
+                : `Based on average daily cost \u2014 only ${previous.length + current.length} days of history available.`}
+            </div>
           </div>
+        ) : (
+          hasData && (
+            <div className="font-mono text-[10px] text-muted mt-1">
+              No prior period data available to calculate a trend.
+            </div>
+          )
         )}
       </div>
 

--- a/src/src/pages/capabilities/costs/index.jsx
+++ b/src/src/pages/capabilities/costs/index.jsx
@@ -4,48 +4,58 @@ import PageSection from "../../../components/PageSection";
 import { getFinoutLinkForCostCentre } from "./finoutCostCentreLink";
 import { useCapabilitiesCost } from "@/state/remote/queries/platformdataapi";
 import { TrackedButton } from "@/components/Tracking";
-import { StatCard } from "@/components/ui/StatCard";
+import { LargeCapabilityCostSummary } from "@/components/BasicCapabilityCost";
 
 export default function Costs({ anchorId, costCentre }) {
-  const { query, getCostsForCapability } = useCapabilitiesCost();
+  const { getCostComparisonForCapability } = useCapabilitiesCost();
   const { id } = useParams();
-  const [showCostsSpinner, setShowCostsSpinner] = useState(true);
-  const dayWindows = [7, 14, 30];
 
-  useEffect(() => {
-    setShowCostsSpinner(!query.isFetched);
-  }, [query.isFetched]);
+  const { current, previous } = getCostComparisonForCapability(id);
+  const totalCost = current.reduce((acc, x) => acc + x.pv, 0);
+  const previousTotal = previous.reduce((acc, x) => acc + x.pv, 0);
+  const hasData = current.length > 0;
+
+  const trendPct =
+    hasData && previous.length > 0 && previousTotal > 0
+      ? ((totalCost - previousTotal) / previousTotal) * 100
+      : null;
+  const isLower = trendPct != null && trendPct < 0;
 
   return (
     <PageSection id={anchorId} headline="Costs">
-      <p className="text-[13px] text-[#666666] dark:text-slate-400 leading-[1.6] mb-4">
-        Use Finout to explore the costs for this capability or its entire cost
-        centre, if a cost centre is set.
-      </p>
-
-      <div className="grid grid-cols-3 gap-3 mb-4">
-        {dayWindows.map((days, index) => {
-          const dataValue = getCostsForCapability(id, days);
-          const totalCost = dataValue.reduce((acc, x) => acc + x.pv, 0);
-          const hasData = dataValue.length > 0;
-
-          return (
-            <StatCard
-              key={index}
-              loading={showCostsSpinner}
-              value={`$${totalCost}`}
-              hasData={hasData}
-              label={`Last ${days} days`}
-            />
-          );
-        })}
+      <div className="mb-4">
+        <span className="font-mono text-[1.5rem] font-bold text-action">
+          {hasData ? `$${Math.floor(totalCost)}` : "No data"}
+        </span>
+        <span className="font-mono text-[11px] text-muted ml-2">total last 30 days</span>
+        {trendPct != null && (
+          <div
+            className="font-mono text-[12px] font-semibold mt-1"
+            style={{ color: isLower ? "#1a7f3c" : "#c0392b" }}
+          >
+            {isLower ? "↓" : "↑"} {Math.abs(Math.round(trendPct))}% vs previous 30 days
+          </div>
+        )}
       </div>
+
+      {hasData && (
+        <div className="mb-4">
+          <LargeCapabilityCostSummary data={current} />
+        </div>
+      )}
+
+      <p className="text-[13px] text-[#666666] dark:text-slate-400 leading-[1.6] mb-4">
+        Use Finout to explore the costs for this capability
+        {costCentre
+          ? ` or its entire cost centre (${costCentre}).`
+          : `. No cost centre is set on this capability.`}
+      </p>
 
       <div className="flex gap-2 flex-wrap">
         <a
           target="_blank"
           rel="noreferrer"
-          href={`${getFinoutLinkForCostCentre({ costCentre })}`}
+          href={costCentre ? `${getFinoutLinkForCostCentre({ costCentre })}` : undefined}
         >
           <TrackedButton
             trackName="FinOutButtonForCostCenter"
@@ -53,7 +63,7 @@ export default function Costs({ anchorId, costCentre }) {
             variation="primary"
             disabled={!costCentre}
           >
-            Entire cost center {costCentre && `(${costCentre})`}
+            {costCentre ? `Cost centre: ${costCentre}` : "Cost centre: not available"}
           </TrackedButton>
         </a>
         <a

--- a/src/src/pages/capabilities/details.jsx
+++ b/src/src/pages/capabilities/details.jsx
@@ -265,7 +265,7 @@ function CapabilityDetailsPageContent() {
             </section>
           </div>
 
-          {showCosts && awsAccount !== undefined && (
+          {showCosts && (
             <div
               className="animate-section-enter"
               style={{ animationDelay: "400ms" }}
@@ -304,8 +304,8 @@ function CapabilityDetailsPageContent() {
                   key={href}
                   href={href}
                   className={`block pl-3.5 pr-4 py-[0.3rem] font-mono text-[11px] no-underline tracking-[0.03em] transition-colors border-l-2 ${isActive
-                      ? "text-[#0e7cc1] dark:text-[#60a5fa] border-[#0e7cc1] dark:border-[#60a5fa]"
-                      : "text-[#666666] dark:text-slate-400 hover:text-[#0e7cc1] dark:hover:text-[#60a5fa] hover:bg-[#f2f2f2] dark:hover:bg-slate-700 border-transparent"
+                    ? "text-[#0e7cc1] dark:text-[#60a5fa] border-[#0e7cc1] dark:border-[#60a5fa]"
+                    : "text-[#666666] dark:text-slate-400 hover:text-[#0e7cc1] dark:hover:text-[#60a5fa] hover:bg-[#f2f2f2] dark:hover:bg-slate-700 border-transparent"
                     }`}
                 >
                   {label}

--- a/src/src/pages/frontpage/MyCapabilities.jsx
+++ b/src/src/pages/frontpage/MyCapabilities.jsx
@@ -5,7 +5,7 @@ import { useMe } from "@/state/remote/queries/me";
 import { useCapabilitiesCost } from "@/state/remote/queries/platformdataapi";
 import { SkeletonCapabilityTableRow } from "@/components/ui/skeleton";
 import { LightBulb } from "@/pages/capabilities/RequirementsStatus";
-import { AlertCircle, Users } from "lucide-react";
+import { AlertCircle, Users, TrendingDown, TrendingUp } from "lucide-react";
 
 const MAX_SHOWN = 5;
 
@@ -17,12 +17,22 @@ function isStaleScore(cap) {
   );
 }
 
-function CostSparkline({ costs }) {
+function CostSparkline({ costs, previousCosts }) {
   const hasCosts = costs && costs.length > 0;
   const avg = hasCosts
     ? Math.floor(costs.reduce((s, x) => s + x.pv, 0) / costs.length)
     : null;
   const avgText = avg == null ? "No data" : avg < 1 ? "<$1/d" : `$${avg}/d`;
+
+  const prevAvg =
+    previousCosts && previousCosts.length > 0
+      ? previousCosts.reduce((s, x) => s + x.pv, 0) / previousCosts.length
+      : null;
+  const trendPct =
+    avg != null && prevAvg != null && prevAvg > 0
+      ? ((avg - prevAvg) / prevAvg) * 100
+      : null;
+  const isLower = trendPct != null && trendPct < 0;
 
   return (
     <div className="flex items-center gap-1.5 shrink-0">
@@ -43,6 +53,20 @@ function CostSparkline({ costs }) {
         </div>
       )}
       <span className="font-mono text-[10px] text-muted">{avgText}</span>
+      {trendPct != null && (
+        <span
+          className="font-mono text-[10px] font-semibold"
+          style={{ color: isLower ? "#1a7f3c" : "#c0392b" }}
+          title={`vs. previous 30 days`}
+        >
+          {isLower ? (
+            <TrendingDown size={11} style={{ display: "inline", marginRight: 2 }} />
+          ) : (
+            <TrendingUp size={11} style={{ display: "inline", marginRight: 2 }} />
+          )}
+          {Math.abs(Math.round(trendPct))}%
+        </span>
+      )}
     </div>
   );
 }
@@ -57,9 +81,8 @@ function CapabilityItem({ cap, index }) {
 
   return (
     <div
-      className={`py-[0.625rem] border-b border-[#eeeeee] dark:border-[#1e2d3d] first:pt-0 last:border-0 last:pb-0 animate-fade-up${
-        isPendingDeletion ? " opacity-70" : ""
-      }`}
+      className={`py-[0.625rem] border-b border-[#eeeeee] dark:border-[#1e2d3d] first:pt-0 last:border-0 last:pb-0 animate-fade-up${isPendingDeletion ? " opacity-70" : ""
+        }`}
       style={{ animationDelay: `${index * 50}ms` }}
     >
       {/* Name row */}
@@ -108,7 +131,7 @@ function CapabilityItem({ cap, index }) {
             </span>
           )}
 
-          <CostSparkline costs={cap.costs} />
+          <CostSparkline costs={cap.costs} previousCosts={cap.previousCosts} />
         </div>
       </div>
     </div>
@@ -117,14 +140,17 @@ function CapabilityItem({ cap, index }) {
 
 export default function MyCapabilities() {
   const { isFetched: meFetched, data: meData } = useMe();
-  const { query: costsQuery, getCostsForCapability } = useCapabilitiesCost();
+  const { query: costsQuery, getCostComparisonForCapability } = useCapabilitiesCost();
 
   const mine = useMemo(() => {
     if (!meFetched || !meData?.capabilities) return [];
     return [...meData.capabilities]
       .sort((a, b) => (b.priorityScore ?? 0) - (a.priorityScore ?? 0))
       .slice(0, MAX_SHOWN)
-      .map((cap) => ({ ...cap, costs: getCostsForCapability(cap.id, 14) }));
+      .map((cap) => {
+        const { current, previous } = getCostComparisonForCapability(cap.id);
+        return { ...cap, costs: current, previousCosts: previous };
+      });
   }, [meFetched, meData, costsQuery.isFetched]);
 
   if (!meFetched) {

--- a/src/src/pages/frontpage/MyCapabilities.jsx
+++ b/src/src/pages/frontpage/MyCapabilities.jsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { LineChart, Line, ResponsiveContainer } from "recharts";
 import { useMe } from "@/state/remote/queries/me";
 import { useCapabilitiesCost } from "@/state/remote/queries/platformdataapi";
 import { SkeletonCapabilityTableRow } from "@/components/ui/skeleton";
 import { LightBulb } from "@/pages/capabilities/RequirementsStatus";
-import { AlertCircle, Users, TrendingDown, TrendingUp } from "lucide-react";
+import { AlertCircle, Users } from "lucide-react";
+import CapabilityCostSummary from "@/components/BasicCapabilityCost";
 
 const MAX_SHOWN = 5;
 
@@ -14,60 +14,6 @@ function isStaleScore(cap) {
     !cap.modifiedAt ||
     cap.requirementScore == null ||
     new Date(cap.modifiedAt) < new Date(Date.now() - 14 * 86400000)
-  );
-}
-
-function CostSparkline({ costs, previousCosts }) {
-  const hasCosts = costs && costs.length > 0;
-  const avg = hasCosts
-    ? Math.floor(costs.reduce((s, x) => s + x.pv, 0) / costs.length)
-    : null;
-  const avgText = avg == null ? "No data" : avg < 1 ? "<$1/d" : `$${avg}/d`;
-
-  const prevAvg =
-    previousCosts && previousCosts.length > 0
-      ? previousCosts.reduce((s, x) => s + x.pv, 0) / previousCosts.length
-      : null;
-  const trendPct =
-    avg != null && prevAvg != null && prevAvg > 0
-      ? ((avg - prevAvg) / prevAvg) * 100
-      : null;
-  const isLower = trendPct != null && trendPct < 0;
-
-  return (
-    <div className="flex items-center gap-1.5 shrink-0">
-      {hasCosts && (
-        <div style={{ width: 48, height: 20 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={costs}>
-              <Line
-                type="monotone"
-                dataKey="pv"
-                stroke="#0e7cc1"
-                strokeWidth={1.5}
-                dot={false}
-                isAnimationActive={false}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      )}
-      <span className="font-mono text-[10px] text-muted">{avgText}</span>
-      {trendPct != null && (
-        <span
-          className="font-mono text-[10px] font-semibold"
-          style={{ color: isLower ? "#1a7f3c" : "#c0392b" }}
-          title={`vs. previous 30 days`}
-        >
-          {isLower ? (
-            <TrendingDown size={11} style={{ display: "inline", marginRight: 2 }} />
-          ) : (
-            <TrendingUp size={11} style={{ display: "inline", marginRight: 2 }} />
-          )}
-          {Math.abs(Math.round(trendPct))}%
-        </span>
-      )}
-    </div>
   );
 }
 
@@ -131,7 +77,7 @@ function CapabilityItem({ cap, index }) {
             </span>
           )}
 
-          <CostSparkline costs={cap.costs} previousCosts={cap.previousCosts} />
+          <CapabilityCostSummary data={cap.costs} previousData={cap.previousCosts} />
         </div>
       </div>
     </div>

--- a/src/src/pages/frontpage/MyCapabilities.jsx
+++ b/src/src/pages/frontpage/MyCapabilities.jsx
@@ -77,7 +77,7 @@ function CapabilityItem({ cap, index }) {
             </span>
           )}
 
-          <CapabilityCostSummary data={cap.costs} previousData={cap.previousCosts} />
+          <CapabilityCostSummary data={cap.costs} previousData={cap.previousCosts} previousDataIsFull={cap.costsComparisonIsFull} />
         </div>
       </div>
     </div>
@@ -94,8 +94,8 @@ export default function MyCapabilities() {
       .sort((a, b) => (b.priorityScore ?? 0) - (a.priorityScore ?? 0))
       .slice(0, MAX_SHOWN)
       .map((cap) => {
-        const { current, previous } = getCostComparisonForCapability(cap.id);
-        return { ...cap, costs: current, previousCosts: previous };
+        const { current, previous, hasFullComparison } = getCostComparisonForCapability(cap.id);
+        return { ...cap, costs: current, previousCosts: previous, costsComparisonIsFull: hasFullComparison };
       });
   }, [meFetched, meData, costsQuery.isFetched]);
 

--- a/src/src/state/remote/queries/platformdataapi.ts
+++ b/src/src/state/remote/queries/platformdataapi.ts
@@ -3,6 +3,30 @@ import { ssuRequest } from "../query";
 import { useContext } from "react";
 import PreAppContext from "@/preAppContext";
 
+let useDummyData = true;
+
+/** Generates deterministic dummy cost data for development when the API returns nothing. */
+function generateDummyCosts(capabilityId: string, days: number) {
+  // Seed a simple LCG from the capability ID so each capability looks different
+  // but renders consistently across re-renders.
+  let seed = capabilityId
+    .split("")
+    .reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const rand = () => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return (seed >>> 0) / 0xffffffff;
+  };
+  const baseValue = 20 + rand() * 80; // $20–$100 / day base
+  return Array.from({ length: days }, (_, i) => {
+    const date = new Date();
+    date.setDate(date.getDate() - (days - 1 - i));
+    return {
+      name: date.toISOString().split("T")[0],
+      pv: Math.max(1, Math.floor(baseValue + (rand() - 0.5) * baseValue * 0.4)),
+    };
+  });
+}
+
 export function useCapabilitiesCost() {
   const { isCloudEngineerEnabled } = useContext(PreAppContext);
 
@@ -32,32 +56,57 @@ export function useCapabilitiesCost() {
   });
 
   var getCostsForCapability = (capabilityId, daysWindow) => {
-    if (daysWindow > 30) {
+    if (daysWindow > 60) {
       throw new Error("Days window size is too large");
     }
 
-    if (!query.isFetched) {
+    const realData =
+      query.isFetched &&
+        query.data != null &&
+        query.data.has(capabilityId)
+        ? query.data.get(capabilityId)
+        : null;
+
+    if (realData == null) {
+      if (useDummyData) {
+        // Always generate from a fixed 60-day pool so that any two windows
+        // (e.g. getCostsForCapability(id, 7) and getCostsForCapability(id, 14))
+        // are consistent slices of the same underlying series.
+        return generateDummyCosts(capabilityId, 60).slice(-daysWindow);
+      }
       return [];
     }
 
-    if (query.data == null) {
-      return [];
+    if (realData.length <= daysWindow) {
+      return realData;
     }
+    return realData.slice(-daysWindow);
+  };
 
-    if (!query.data.has(capabilityId)) {
-      return [];
-    }
+  /**
+   * Returns { current, previous } where each is up to 30 days.
+   * current = the most recent 30 days (rendered in chart).
+   * previous = the 30 days before that (used only for trend calculation).
+   */
+  var getCostComparisonForCapability = (capabilityId) => {
+    // Fetch 60 days of raw data internally so we can compute both windows,
+    // but only the last 30 are ever passed to the chart.
+    const rawAll: { name: string; pv: number }[] =
+      query.isFetched && query.data != null && query.data.has(capabilityId)
+        ? query.data.get(capabilityId)
+        : useDummyData
+          ? generateDummyCosts(capabilityId, 60)
+          : [];
 
-    let these_costs = query.data.get(capabilityId);
-    if (these_costs.length <= daysWindow) {
-      return these_costs;
-    }
-    return these_costs.slice(-daysWindow);
+    const current = rawAll.slice(-30); // ← chart always shows exactly 30 days
+    const previous = rawAll.length > 30 ? rawAll.slice(-60, -30) : [];
+    return { current, previous };
   };
 
   return {
     query: query,
     getCostsForCapability: getCostsForCapability,
+    getCostComparisonForCapability: getCostComparisonForCapability,
   };
 }
 

--- a/src/src/state/remote/queries/platformdataapi.ts
+++ b/src/src/state/remote/queries/platformdataapi.ts
@@ -3,7 +3,7 @@ import { ssuRequest } from "../query";
 import { useContext } from "react";
 import PreAppContext from "@/preAppContext";
 
-let useDummyData = true;
+let useDummyData = false;
 
 /** Generates deterministic dummy cost data for development when the API returns nothing. */
 function generateDummyCosts(capabilityId: string, days: number) {

--- a/src/src/state/remote/queries/platformdataapi.ts
+++ b/src/src/state/remote/queries/platformdataapi.ts
@@ -3,7 +3,7 @@ import { ssuRequest } from "../query";
 import { useContext } from "react";
 import PreAppContext from "@/preAppContext";
 
-let useDummyData = false;
+let useDummyData = true;
 
 /** Generates deterministic dummy cost data for development when the API returns nothing. */
 function generateDummyCosts(capabilityId: string, days: number) {
@@ -95,12 +95,20 @@ export function useCapabilitiesCost() {
       query.isFetched && query.data != null && query.data.has(capabilityId)
         ? query.data.get(capabilityId)
         : useDummyData
-          ? generateDummyCosts(capabilityId, 60)
+          ? (() => {
+              // Vary history length per capability so we can test partial-history behaviour:
+              // ~⅓ get 60 days (full comparison), ~⅓ get 45 days, ~⅓ get 20 days.
+              const bucket =
+                capabilityId.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0) % 3;
+              const dummyDays = bucket === 0 ? 60 : bucket === 1 ? 45 : 20;
+              return generateDummyCosts(capabilityId, dummyDays);
+            })()
           : [];
 
     const current = rawAll.slice(-30); // ← chart always shows exactly 30 days
     const previous = rawAll.length > 30 ? rawAll.slice(-60, -30) : [];
-    return { current, previous };
+    const hasFullComparison = rawAll.length >= 60;
+    return { current, previous, hasFullComparison };
   };
 
   return {

--- a/src/src/state/remote/queries/platformdataapi.ts
+++ b/src/src/state/remote/queries/platformdataapi.ts
@@ -3,7 +3,7 @@ import { ssuRequest } from "../query";
 import { useContext } from "react";
 import PreAppContext from "@/preAppContext";
 
-let useDummyData = true;
+let useDummyData = false;
 
 /** Generates deterministic dummy cost data for development when the API returns nothing. */
 function generateDummyCosts(capabilityId: string, days: number) {
@@ -96,13 +96,13 @@ export function useCapabilitiesCost() {
         ? query.data.get(capabilityId)
         : useDummyData
           ? (() => {
-              // Vary history length per capability so we can test partial-history behaviour:
-              // ~⅓ get 60 days (full comparison), ~⅓ get 45 days, ~⅓ get 20 days.
-              const bucket =
-                capabilityId.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0) % 3;
-              const dummyDays = bucket === 0 ? 60 : bucket === 1 ? 45 : 20;
-              return generateDummyCosts(capabilityId, dummyDays);
-            })()
+            // Vary history length per capability so we can test partial-history behaviour:
+            // ~⅓ get 60 days (full comparison), ~⅓ get 45 days, ~⅓ get 20 days.
+            const bucket =
+              capabilityId.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0) % 3;
+            const dummyDays = bucket === 0 ? 60 : bucket === 1 ? 45 : 20;
+            return generateDummyCosts(capabilityId, dummyDays);
+          })()
           : [];
 
     const current = rawAll.slice(-30); // ← chart always shows exactly 30 days


### PR DESCRIPTION

🌟 Changes:
- Remove cost graphs from capabilities overview
- Add total 30 day cost and trend on capabilities overview
- Remove 7, 14, 30 day cost cards from capability details cost section
- Add 30 day cost graph to capability details cost section
- Add 30 day cost and trend to capability details cost section
- Add 30 day cost and trend to MyCapabilities on the front page

🎶 Notes:
- If less than 30 days of data is available, will not render trend but indicate the lack of data
- If 31-59 days of data is available, will calculate trend, but mark it as uncertain (`~`)
- Trends are described in more detail on the capability page

🖼️ Screenshots:
<img width="2183" height="479" alt="image" src="https://github.com/user-attachments/assets/da400dfa-63db-4a15-a65b-10d1f9b002b5" />
<img width="3592" height="665" alt="image" src="https://github.com/user-attachments/assets/cba16c04-7804-4427-8043-cf4804362d53" />
<img width="3376" height="575" alt="image" src="https://github.com/user-attachments/assets/8f671601-a298-4251-a3c9-1936963d986c" />
<img width="3365" height="538" alt="image" src="https://github.com/user-attachments/assets/76b077ba-ba2a-441d-9357-c76e9b2b3f13" />

