### PR TITLE
add descriptions to new groups

### DIFF
--- a/src/src/pages/admin/rbac/index.tsx
+++ b/src/src/pages/admin/rbac/index.tsx
@@ -561,6 +561,7 @@ export default function RbacViewerPage() {
   const [tab, setTab] = useState<Tab>("roles");
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [newGroupName, setNewGroupName] = useState("");
+  const [newGroupDescription, setNewGroupDescription] = useState("");
   const [showCreateRole, setShowCreateRole] = useState(false);
   const [newRoleName, setNewRoleName] = useState("");
   const [newRoleDescription, setNewRoleDescription] = useState("");
@@ -611,8 +612,7 @@ export default function RbacViewerPage() {
     queryClient.invalidateQueries({ queryKey: ["rbac", "role-permissions"] });
     if (failed > 0) {
       toast.error(
-        `${selectedPerms.size - failed}/${
-          selectedPerms.size
+        `${selectedPerms.size - failed}/${selectedPerms.size
         } permissions granted`,
       );
     } else {
@@ -649,6 +649,7 @@ export default function RbacViewerPage() {
     errorMessage: "Could not create group",
     onSuccess: () => {
       setNewGroupName("");
+      setNewGroupDescription("");
       setShowCreateGroup(false);
     },
   });
@@ -673,8 +674,8 @@ export default function RbacViewerPage() {
 
   function handleCreateGroup(e: React.FormEvent) {
     e.preventDefault();
-    if (!newGroupName.trim()) return;
-    fireCreateGroup({ name: newGroupName.trim() });
+    if (!newGroupName.trim() || !newGroupDescription.trim()) return;
+    fireCreateGroup({ name: newGroupName.trim(), description: newGroupDescription.trim() });
   }
 
   return (
@@ -868,7 +869,7 @@ export default function RbacViewerPage() {
           {showCreateGroup && (
             <form
               onSubmit={handleCreateGroup}
-              className="flex gap-2 mb-4 p-3 border border-card rounded-[8px] bg-surface-muted/40"
+              className="flex flex-col gap-2 mb-4 p-3 border border-card rounded-[8px] bg-surface-muted/40"
             >
               <Input
                 placeholder="Group name"
@@ -877,25 +878,34 @@ export default function RbacViewerPage() {
                 className="text-sm font-mono"
                 autoFocus
               />
-              <Button
-                type="submit"
-                variant="default"
-                size="sm"
-                disabled={!newGroupName.trim() || createGroup.isPending}
-              >
-                {createGroup.isPending ? "Creating…" : "Create"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setShowCreateGroup(false);
-                  setNewGroupName("");
-                }}
-              >
-                Cancel
-              </Button>
+              <Input
+                placeholder="Description"
+                value={newGroupDescription}
+                onChange={(e) => setNewGroupDescription(e.target.value)}
+                className="text-sm"
+              />
+              <div className="flex gap-2 justify-end">
+                <Button
+                  type="submit"
+                  variant="default"
+                  size="sm"
+                  disabled={!newGroupName.trim() || !newGroupDescription.trim() || createGroup.isPending}
+                >
+                  {createGroup.isPending ? "Creating…" : "Create"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setShowCreateGroup(false);
+                    setNewGroupName("");
+                    setNewGroupDescription("");
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
             </form>
           )}
 

--- a/src/src/pages/admin/rbac/manage/GroupInspector.tsx
+++ b/src/src/pages/admin/rbac/manage/GroupInspector.tsx
@@ -84,6 +84,9 @@ export function GroupInspector({ groupId, onDeleted }: GroupInspectorProps) {
             {group.name ?? group.id}
           </h2>
           <p className="text-xs text-muted font-mono truncate">{group.id}</p>
+          {group.description && (
+            <p className="text-sm text-foreground mt-1.5">{group.description}</p>
+          )}
         </div>
         <Button
           variant="outline"

--- a/src/src/pages/admin/rbac/manage/index.tsx
+++ b/src/src/pages/admin/rbac/manage/index.tsx
@@ -355,6 +355,7 @@ function GroupList({
   const [filter, setFilter] = useState("");
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
+  const [newDescription, setNewDescription] = useState("");
 
   const createMutation = useCreateRbacGroup();
   const fireCreate = useMutationToast(createMutation, {
@@ -364,6 +365,7 @@ function GroupList({
     onSuccess: (data: any) => {
       setShowCreate(false);
       setNewName("");
+      setNewDescription("");
       if (data?.id) onSelect(data.id);
     },
   });
@@ -457,8 +459,8 @@ function GroupList({
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              if (!newName.trim()) return;
-              fireCreate({ name: newName.trim() });
+              if (!newName.trim() || !newDescription.trim()) return;
+              fireCreate({ name: newName.trim(), description: newDescription.trim() });
             }}
             className="space-y-4 mt-2"
           >
@@ -470,6 +472,15 @@ function GroupList({
                 placeholder="e.g. platform-admins"
                 className="text-sm font-mono"
                 autoFocus
+              />
+            </div>
+            <div>
+              <SectionLabel className="block mb-1.5">Description</SectionLabel>
+              <Input
+                value={newDescription}
+                onChange={(e) => setNewDescription(e.target.value)}
+                placeholder="e.g. Members with platform admin privileges"
+                className="text-sm"
               />
             </div>
             <div className="flex gap-2 justify-end pt-2">
@@ -484,7 +495,7 @@ function GroupList({
               <Button
                 type="submit"
                 variant="action"
-                disabled={!newName.trim() || createMutation.isPending}
+                disabled={!newName.trim() || !newDescription.trim() || createMutation.isPending}
               >
                 {createMutation.isPending ? "Creating…" : "Create"}
               </Button>

--- a/src/src/state/remote/queries/rbac.ts
+++ b/src/src/state/remote/queries/rbac.ts
@@ -157,7 +157,10 @@ export const useCanThey = createSsuMutation<any>({
 export const useCreateRbacGroup = createSsuMutation<any>({
   method: "POST",
   urlSegments: () => ["rbac", "groups"],
-  payload: (data) => data,
+  payload: (data) => ({
+    name: data.name,
+    description: data.description || "",
+  }),
   authMode: true,
 });
 


### PR DESCRIPTION
🌟 Changes:
- Force users to add description to RBAC groups during creation
- Show group description

🎶 Notes:
This solves the issue with the server rejecting new groups created due to missing descriptions.
I prefer forcing a description than allowing it to not exist.