### PR TITLE
Fix/align missing compliance metric indicators

### DIFF
--- a/src/src/pages/compliance/cost-centre-detail.tsx
+++ b/src/src/pages/compliance/cost-centre-detail.tsx
@@ -101,6 +101,9 @@ const STATUS_FILTERS: { key: StatusFilter; label: string }[] = [
   { key: "Unknown", label: "Unknown" },
 ];
 
+const NA_TOOLTIP =
+  "N/A means that either no compliance data is available for this value yet or that the data shows no items in this category.";
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function statusLabel(s: string): string {
@@ -675,6 +678,7 @@ function SummaryCell({
       <span
         className="text-[1.25rem] font-bold font-mono leading-none"
         style={{ color: value === null ? undefined : color }}
+        title={value === null ? NA_TOOLTIP : undefined}
       >
         {value === null ? "N/A" : value}
       </span>
@@ -790,7 +794,9 @@ function CapabilityMatrix({
               {ratio.compliant} / {ratio.total}
             </span>
           ) : (
-            <span className="text-muted text-[0.75rem]">N/A</span>
+            <span className="text-muted text-[0.75rem]" title={NA_TOOLTIP}>
+              N/A
+            </span>
           );
         },
       })),
@@ -819,6 +825,7 @@ function CapabilityMatrix({
             <span
               className="font-mono text-[0.8125rem] font-semibold"
               style={{ color }}
+              title={cap.overallStatus === "Unknown" ? NA_TOOLTIP : undefined}
             >
               {cap.overallStatus === "Unknown" ? "N/A" : `${pct}%`}
             </span>
@@ -1019,7 +1026,7 @@ function ExpandedDetail({
                   <span className="text-muted truncate max-w-[40%]">{k}</span>
                   <span className="text-muted">=</span>
                   <span className="text-primary truncate flex-1">
-                    {v || "N/A"}
+                    <span title={v ? undefined : NA_TOOLTIP}>{v || "N/A"}</span>
                   </span>
                 </div>
               ))}
@@ -1151,6 +1158,7 @@ function MobileCapabilityCard({
           <div
             className="text-[1rem] font-bold font-mono flex-shrink-0"
             style={{ color: overallColor }}
+            title={cap.overallStatus === "Unknown" ? NA_TOOLTIP : undefined}
           >
             {cap.overallStatus === "Unknown" ? "N/A" : `${pct}%`}
           </div>
@@ -1177,7 +1185,9 @@ function MobileCapabilityCard({
                     {ratio.compliant} / {ratio.total}
                   </span>
                 ) : (
-                  <span className="text-muted text-[0.75rem]">N/A</span>
+                  <span className="text-muted text-[0.75rem]" title={NA_TOOLTIP}>
+                    N/A
+                  </span>
                 )}
                 <span className="text-[0.5625rem] font-mono uppercase tracking-[0.08em] text-muted">
                   {c.short}

--- a/src/src/pages/compliance/cost-centre-detail.tsx
+++ b/src/src/pages/compliance/cost-centre-detail.tsx
@@ -676,7 +676,7 @@ function SummaryCell({
         className="text-[1.25rem] font-bold font-mono leading-none"
         style={{ color: value === null ? undefined : color }}
       >
-        {value === null ? "-" : value}
+        {value === null ? "N/A" : value}
       </span>
     </div>
   );
@@ -782,7 +782,7 @@ function CapabilityMatrix({
         muiTableBodyCellProps: { align: "center" },
         Cell: ({ row }) => {
           const ratio = categoryRatio(findCategory(row.original, c.key));
-          return ratio ? (
+          return ratio && ratio.total > 0 ? (
             <span
               className="font-mono text-[0.75rem] tabular-nums font-semibold"
               style={{ color: ratioColor(ratio) }}
@@ -790,7 +790,7 @@ function CapabilityMatrix({
               {ratio.compliant} / {ratio.total}
             </span>
           ) : (
-            <span className="text-muted text-[0.75rem]">-</span>
+            <span className="text-muted text-[0.75rem]">N/A</span>
           );
         },
       })),
@@ -820,7 +820,7 @@ function CapabilityMatrix({
               className="font-mono text-[0.8125rem] font-semibold"
               style={{ color }}
             >
-              {cap.overallStatus === "Unknown" ? "-" : `${pct}%`}
+              {cap.overallStatus === "Unknown" ? "N/A" : `${pct}%`}
             </span>
           );
         },
@@ -1019,7 +1019,7 @@ function ExpandedDetail({
                   <span className="text-muted truncate max-w-[40%]">{k}</span>
                   <span className="text-muted">=</span>
                   <span className="text-primary truncate flex-1">
-                    {v || "-"}
+                    {v || "N/A"}
                   </span>
                 </div>
               ))}
@@ -1152,7 +1152,7 @@ function MobileCapabilityCard({
             className="text-[1rem] font-bold font-mono flex-shrink-0"
             style={{ color: overallColor }}
           >
-            {cap.overallStatus === "Unknown" ? "-" : `${pct}%`}
+            {cap.overallStatus === "Unknown" ? "N/A" : `${pct}%`}
           </div>
           <ChevronDown
             size={14}
@@ -1169,7 +1169,7 @@ function MobileCapabilityCard({
             const ratio = categoryRatio(cat);
             return (
               <div key={c.key} className="flex flex-col items-center gap-1">
-                {ratio ? (
+                {ratio && ratio.total > 0 ? (
                   <span
                     className="font-mono text-[0.6875rem] tabular-nums font-semibold"
                     style={{ color: ratioColor(ratio) }}
@@ -1177,7 +1177,7 @@ function MobileCapabilityCard({
                     {ratio.compliant} / {ratio.total}
                   </span>
                 ) : (
-                  <span className="text-muted text-[0.75rem]">-</span>
+                  <span className="text-muted text-[0.75rem]">N/A</span>
                 )}
                 <span className="text-[0.5625rem] font-mono uppercase tracking-[0.08em] text-muted">
                   {c.short}

--- a/src/src/pages/compliance/index.tsx
+++ b/src/src/pages/compliance/index.tsx
@@ -166,6 +166,7 @@ function CostCentreCard({
   const total = data?.totalCapabilities ?? capCount;
   const compliant = data?.compliantCount ?? 0;
   const pct = total > 0 ? Math.round((compliant / total) * 100) : 100;
+  const compliantDisplay = total > 0 ? `${compliant}/${total}` : "N/A";
   const color = isFetched ? complianceColor(pct) : "var(--color-border-card)";
   const categories = data?.categories ?? [];
   const { trackEvent } = useRybbit();
@@ -214,7 +215,7 @@ function CostCentreCard({
                 {pct}%
               </div>
               <div className="text-[0.625rem] text-[#afafaf] dark:text-[#64748b] mt-0.5 font-mono">
-                {compliant}/{total}
+                {compliantDisplay}
               </div>
             </>
           ) : (
@@ -509,7 +510,7 @@ export default function CompliancePage() {
                     Total Count
                   </span>
                   <span className="text-[1.125rem] font-bold text-[#002b45] dark:text-[#e2e8f0] font-mono leading-none">
-                    {fetchedCount > 0 ? totalCaps : "-"}
+                    {fetchedCount > 0 ? totalCaps : "N/A"}
                   </span>
                 </div>
                 <div className="flex flex-col items-center gap-1.5">
@@ -522,7 +523,7 @@ export default function CompliancePage() {
                       color: fetchedCount > 0 ? "#16a34a" : undefined,
                     }}
                   >
-                    {fetchedCount > 0 ? totalCompliant : "-"}
+                    {fetchedCount > 0 ? totalCompliant : "N/A"}
                   </span>
                 </div>
                 <div className="flex flex-col items-center gap-1.5">
@@ -535,7 +536,7 @@ export default function CompliancePage() {
                       color: fetchedCount > 0 ? gaugeColor : undefined,
                     }}
                   >
-                    {fetchedCount > 0 ? `${overallPct}%` : "-"}
+                    {fetchedCount > 0 ? `${overallPct}%` : "N/A"}
                   </span>
                 </div>
               </div>

--- a/src/src/pages/compliance/index.tsx
+++ b/src/src/pages/compliance/index.tsx
@@ -46,6 +46,9 @@ const SORT_OPTIONS: { key: SortMode; label: string }[] = [
   { key: "caps", label: "Largest first" },
 ];
 
+const NA_TOOLTIP =
+  "N/A means that either no compliance data is available for this value yet or that the data shows no items in this category.";
+
 // ─── DonutChart ──────────────────────────────────────────────────────────────
 
 function DonutChart({
@@ -215,7 +218,9 @@ function CostCentreCard({
                 {pct}%
               </div>
               <div className="text-[0.625rem] text-[#afafaf] dark:text-[#64748b] mt-0.5 font-mono">
-                {compliantDisplay}
+                <span title={compliantDisplay === "N/A" ? NA_TOOLTIP : undefined}>
+                  {compliantDisplay}
+                </span>
               </div>
             </>
           ) : (
@@ -510,7 +515,9 @@ export default function CompliancePage() {
                     Total Count
                   </span>
                   <span className="text-[1.125rem] font-bold text-[#002b45] dark:text-[#e2e8f0] font-mono leading-none">
-                    {fetchedCount > 0 ? totalCaps : "N/A"}
+                    <span title={fetchedCount > 0 ? undefined : NA_TOOLTIP}>
+                      {fetchedCount > 0 ? totalCaps : "N/A"}
+                    </span>
                   </span>
                 </div>
                 <div className="flex flex-col items-center gap-1.5">
@@ -523,7 +530,9 @@ export default function CompliancePage() {
                       color: fetchedCount > 0 ? "#16a34a" : undefined,
                     }}
                   >
-                    {fetchedCount > 0 ? totalCompliant : "N/A"}
+                    <span title={fetchedCount > 0 ? undefined : NA_TOOLTIP}>
+                      {fetchedCount > 0 ? totalCompliant : "N/A"}
+                    </span>
                   </span>
                 </div>
                 <div className="flex flex-col items-center gap-1.5">
@@ -536,7 +545,9 @@ export default function CompliancePage() {
                       color: fetchedCount > 0 ? gaugeColor : undefined,
                     }}
                   >
-                    {fetchedCount > 0 ? `${overallPct}%` : "N/A"}
+                    <span title={fetchedCount > 0 ? undefined : NA_TOOLTIP}>
+                      {fetchedCount > 0 ? `${overallPct}%` : "N/A"}
+                    </span>
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
🌟 Changes:
- Use `N/A` throughout, replacing '0/0' and '-' to represent 'no relevant data available'.
- Added title to explain to users how to interpret this