### PR TITLE
handle frontpagesummary for news items

### DIFF
--- a/src/src/pages/frontpage/index.jsx
+++ b/src/src/pages/frontpage/index.jsx
@@ -85,21 +85,42 @@ export default function FrontPage() {
   const highlighted =
     newsData?.newsItems?.filter((item) => item.isHighlighted) ?? [];
 
+  const getHighlightedBody = (item) =>
+    item.frontpageSummary || item.body || "";
+
   return (
     <div className="p-4 sm:p-8">
       <HeroRow name={name} />
 
       {/* Highlighted notices from relevant news */}
-      {highlighted.map((item, i) => (
-        <div
-          key={item.id}
-          className="mb-[1.75rem] bg-[rgba(237,136,0,0.1)] dark:bg-[rgba(237,136,0,0.08)] border border-[rgba(237,136,0,0.25)] dark:border-[rgba(237,136,0,0.2)] rounded-[6px] px-4 py-3 font-mono text-[0.75rem] text-[#ed8800] leading-[1.6] animate-fade-up"
-          style={{ animationDelay: `${40 + i * 40}ms` }}
-        >
-          <span className="font-bold tracking-[0.05em]">{item.title} - </span>
-          <LinkifiedText text={item.body ?? ""} linkClassName="underline" />
-        </div>
-      ))}
+      {highlighted.map((item, i) => {
+        const hasFrontpageSummary = Boolean(item.frontpageSummary?.trim());
+
+        return (
+          <div
+            key={item.id}
+            className="mb-[1.75rem] bg-[rgba(237,136,0,0.1)] dark:bg-[rgba(237,136,0,0.08)] border border-[rgba(237,136,0,0.25)] dark:border-[rgba(237,136,0,0.2)] rounded-[6px] px-4 py-3 font-mono text-[0.75rem] text-[#ed8800] leading-[1.6] animate-fade-up"
+            style={{ animationDelay: `${40 + i * 40}ms` }}
+          >
+            <span className="font-bold tracking-[0.05em]">{item.title} - </span>
+            <LinkifiedText
+              text={getHighlightedBody(item)}
+              linkClassName="underline"
+            />
+            {hasFrontpageSummary && (
+              <>
+                {" "}
+                <Link
+                  to={`/news/v/${item.id}`}
+                  className="text-inherit underline"
+                >
+                  [read more]
+                </Link>
+              </>
+            )}
+          </div>
+        );
+      })}
 
       {/* 3-column grid */}
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_2fr_1fr] gap-5 items-start">

--- a/src/src/pages/news/index.jsx
+++ b/src/src/pages/news/index.jsx
@@ -31,6 +31,7 @@ import LinkifiedText from "@/components/Text/LinkifiedText";
 function CreateNewsModal({ onClose }) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  const [frontpageSummary, setFrontpageSummary] = useState("");
   const [dueDate, setDueDate] = useState(
     new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
   );
@@ -52,10 +53,14 @@ function CreateNewsModal({ onClose }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!title.trim() || !body.trim()) return;
+    const trimmedFrontpageSummary = frontpageSummary.trim();
     submit({
       payload: {
         title: title.trim(),
         body: body.trim(),
+        ...(trimmedFrontpageSummary
+          ? { frontpageSummary: trimmedFrontpageSummary }
+          : {}),
         dueDate: new Date(dueDate).toISOString(),
       },
     });
@@ -101,6 +106,19 @@ function CreateNewsModal({ onClose }) {
 
           <div>
             <label className="block text-[0.75rem] font-semibold text-secondary mb-1">
+              Front page summary
+            </label>
+            <textarea
+              value={frontpageSummary}
+              onChange={(e) => setFrontpageSummary(e.target.value)}
+              placeholder="Optional summary shown for highlighted items on the front page…"
+              rows={3}
+              className="w-full rounded-[6px] border border-card bg-surface px-3 py-2 text-[0.8125rem] text-primary placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-action resize-y"
+            />
+          </div>
+
+          <div>
+            <label className="block text-[0.75rem] font-semibold text-secondary mb-1">
               Relevant until
             </label>
             <input
@@ -136,11 +154,15 @@ function EditNewsModal({ item, onClose }) {
   const initialDueDate = item.dueDate ? item.dueDate.slice(0, 10) : "";
   const [title, setTitle] = useState(item.title ?? "");
   const [body, setBody] = useState(item.body ?? "");
+  const [frontpageSummary, setFrontpageSummary] = useState(
+    item.frontpageSummary ?? "",
+  );
   const [dueDate, setDueDate] = useState(initialDueDate);
 
   useEffect(() => {
     setTitle(item.title ?? "");
     setBody(item.body ?? "");
+    setFrontpageSummary(item.frontpageSummary ?? "");
     setDueDate(item.dueDate ? item.dueDate.slice(0, 10) : "");
   }, [item]);
 
@@ -163,11 +185,15 @@ function EditNewsModal({ item, onClose }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!title.trim() || !body.trim()) return;
+    const trimmedFrontpageSummary = frontpageSummary.trim();
     submit({
       id: item.id,
       payload: {
         title: title.trim(),
         body: body.trim(),
+        ...(trimmedFrontpageSummary
+          ? { frontpageSummary: trimmedFrontpageSummary }
+          : {}),
         dueDate: new Date(dueDate).toISOString(),
       },
     });
@@ -208,6 +234,19 @@ function EditNewsModal({ item, onClose }) {
               rows={6}
               className="w-full rounded-[6px] border border-card bg-surface px-3 py-2 text-[0.8125rem] text-primary placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-action resize-y"
               required
+            />
+          </div>
+
+          <div>
+            <label className="block text-[0.75rem] font-semibold text-secondary mb-1">
+              Front page summary
+            </label>
+            <textarea
+              value={frontpageSummary}
+              onChange={(e) => setFrontpageSummary(e.target.value)}
+              placeholder="Optional summary shown for highlighted items on the front page…"
+              rows={3}
+              className="w-full rounded-[6px] border border-card bg-surface px-3 py-2 text-[0.8125rem] text-primary placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-action resize-y"
             />
           </div>
 

--- a/src/src/state/remote/queries/news.ts
+++ b/src/src/state/remote/queries/news.ts
@@ -8,6 +8,7 @@ export interface NewsItem {
   id: string;
   title: string;
   body: string;
+  frontpageSummary?: string | null;
   dueDate: string;
   isHighlighted: boolean;
   isRelevant: boolean;
@@ -40,7 +41,12 @@ export const useNewsItem = createSsuParamQuery<string, NewsItem>({
 });
 
 export const useCreateNews = createSsuMutation<{
-  payload: { title: string; body: string; dueDate: string };
+  payload: {
+    title: string;
+    body: string;
+    frontpageSummary?: string;
+    dueDate: string;
+  };
 }>({
   method: "POST",
   urlSegments: () => ["news"],
@@ -48,7 +54,12 @@ export const useCreateNews = createSsuMutation<{
 
 export const useUpdateNews = createSsuMutation<{
   id: string;
-  payload: { title: string; body: string; dueDate: string };
+  payload: {
+    title: string;
+    body: string;
+    frontpageSummary?: string;
+    dueDate: string;
+  };
 }>({
   method: "POST",
   urlSegments: (data) => ["news", data.id],


### PR DESCRIPTION
🌟 Changes:
- News items contains a frontpagesummary.
- If highlighted use frontpagesummary iff present.

🖼️ Screenshots:
<img width="781" height="851" alt="image" src="https://github.com/user-attachments/assets/12d6605e-edf1-41c5-a03c-800aa7a75f41" />
<img width="1515" height="157" alt="image" src="https://github.com/user-attachments/assets/81df0b5d-fe38-46a0-b289-30bbc2ee7f7e" />
<img width="1531" height="369" alt="image" src="https://github.com/user-attachments/assets/8f2fdd3b-f47a-4a5f-ab66-307bf5214f53" />

